### PR TITLE
API end-point to list available ASes.

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,6 +87,9 @@ func main() {
 	// show all request TO this AS
 	router.Handle("/api/as/pollEvents/{account_id}/{secret}", apiChain.ThenFunc(asController.PollEvents))
 
+	// list the ASes the requesting AS can connect to
+	router.Handle("/api/as/listASes/{account_id}/{secret}", apiChain.ThenFunc(asController.ListASes))
+
 	// serve static files
 	static := http.StripPrefix("/public/", http.FileServer(http.Dir("public")))
 	router.PathPrefix("/public/").Handler(xsrfChain.Then(static))

--- a/models/as.go
+++ b/models/as.go
@@ -31,9 +31,15 @@ type As struct {
 	Created time.Time
 }
 
-func FindCoreASesByIsd(isd uint64) ([]As, error) {
+func FindCoreASesByIsd(isd int) ([]As, error) {
 	var ases []As
 	_, err := o.QueryTable("as").Filter("Isd", isd).Filter("Core", true).All(&ases)
+	return ases, err
+}
+
+func FindASesByIsd(isd int) ([]As, error) {
+	var ases []As
+	_, err := o.QueryTable("as").Filter("Isd", isd).All(&ases)
 	return ases, err
 }
 

--- a/models/events.go
+++ b/models/events.go
@@ -28,7 +28,7 @@ type JoinRequest struct {
 	Id            uint64 `orm:"column(id);auto;pk"`
 	RequestId     uint64
 	Info          string // free form text for the reply
-	IsdToJoin     uint64
+	IsdToJoin     int    // the ISD that the sender wants to join
 	JoinAsACoreAS bool   // whether to join the ISD as a core AS
 	RequesterId   string // the key to identify which account made the request
 	RespondIA     string // the ISD-AS which should respond to the request

--- a/models/events_test.go
+++ b/models/events_test.go
@@ -15,7 +15,6 @@
 package models
 
 import (
-	//	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )


### PR DESCRIPTION
This PR adds a simple API end-point to list the available ASes to connect to. It
returns a list of ASes in the ISD which the querying AS belongs to. This
API end-point will be used by scion-web's simple installation mechanism to
display a drop-down menu containing available ASes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/29)
<!-- Reviewable:end -->
