### PR TITLE
Add user email info to GetNewSCIONLabVMASes API response

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -352,8 +352,9 @@ func CopyFile(source string, dest string) (err error) {
 
 type SCIONLabVMResp struct {
 	ASID         string // ISD-AS of the VM
-	VMIP         string // IP address of the SCIONLab VM
 	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
+	UserEmail    string // The email address of the user owning this SCIONLab VM AS
+	VMIP         string // IP address of the SCIONLab VM
 }
 
 // API end-point to serve the list of newly created but not yet activated SCIONLab VMs.
@@ -377,6 +378,7 @@ func (s *SCIONLabVMController) GetNewSCIONLabVMASes(w http.ResponseWriter, r *ht
 			ASID:         strconv.Itoa(v.IA.Isd) + "-" + strconv.Itoa(v.IA.As),
 			VMIP:         v.IP,
 			RemoteIAPort: v.RemoteIAPort,
+			UserEmail:    v.UserEmail,
 		}
 		vms_resp = append(vms_resp, vm_resp)
 	}


### PR DESCRIPTION
This PR adds the user email information to the GetNewSCIONLabVMASes API's
response. This way the designated SCIONLab ASes can receive and store this
information locally. It allows ease-of-debugging and keeping track of which
which border router belongs to which user on a given SCIONLab AS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/49)
<!-- Reviewable:end -->
