### PR TITLE
Ability to update and remove a SCIONLab VM.

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -51,11 +51,11 @@ var (
 
 // The states in which a user's SCIONLab VM can be in.
 const (
-	ACTIVE   = "Active"
-	INACTIVE = "Inactive"
-	CREATE   = "Create"
-	UPDATE   = "Update"
-	REMOVE   = "Remove"
+	INACTIVE = iota // 0
+	ACTIVE
+	CREATE
+	UPDATE
+	REMOVE
 )
 
 // Acknowledgments for the performed operations by a SCIONLab AS.

--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -49,6 +49,22 @@ var (
 	package_path   = filepath.Join(user_path, "scionLabConfigs")
 )
 
+// The states in which a user's SCIONLab VM can be in.
+const (
+	ACTIVE   = "Active"
+	INACTIVE = "Inactive"
+	CREATE   = "Create"
+	UPDATE   = "Update"
+	REMOVE   = "Remove"
+)
+
+// Acknowledgments for the performed operations by a SCIONLab AS.
+const (
+	CREATED = "Created"
+	UPDATED = "Updated"
+	REMOVED = "Removed"
+)
+
 type SCIONLabVMController struct {
 	controllers.HTTPController
 }
@@ -76,10 +92,20 @@ func (s *SCIONLabVMController) GenerateSCIONLabVM(w http.ResponseWriter, r *http
 		s.BadRequest(err, w, r)
 		return
 	}
-	// Target SCIONLab IA to connect to is fixed for now
-	targetIA := "1-7"
-	isdID := 1
-	svmInfo, err := s.getSCIONLabVMInfo(scionLabVMIP, userEmail, targetIA, isdID)
+	// check if there is already a create or update in progress
+	canCreateOrUpdate, err := s.canCreateOrUpdate(userEmail)
+	if err != nil {
+		log.Printf("Error checking pending create or update. User: %v, %v", userEmail, err)
+		s.Error500(err, w, r)
+		return
+	}
+	if !canCreateOrUpdate {
+		s.BadRequest(fmt.Errorf("You have a pending operation. Please wait a few minutes."),
+			w, r)
+		return
+	}
+	// Target SCIONLab ISD and AS to connect to is fixed for now (1-7)
+	svmInfo, err := s.getSCIONLabVMInfo(scionLabVMIP, userEmail, "1-7", 1)
 	if err != nil {
 		log.Printf("Error getting SCIONLabVMInfo: %v", err)
 		s.Error500(err, w, r)
@@ -104,7 +130,7 @@ func (s *SCIONLabVMController) GenerateSCIONLabVM(w http.ResponseWriter, r *http
 		s.Error500(err, w, r)
 		return
 	}
-	// Persist the relevant data in the DB
+	// Persist the relevant data into the DB
 	if err = s.updateDB(svmInfo); err != nil {
 		log.Printf("Error updating DB tables: %v", err)
 		s.Error500(err, w, r)
@@ -125,6 +151,22 @@ func (s *SCIONLabVMController) parseURLParameters(r *http.Request) (string, stri
 		return "", "", fmt.Errorf("IP address cannot be empty. User: %v", userEmail)
 	}
 	return scionLabVMIP, userEmail, nil
+}
+
+// Check if the user's VM is already in the process of being created or updated.
+func (s *SCIONLabVMController) canCreateOrUpdate(userEmail string) (bool, error) {
+	svm, err := models.FindSCIONLabVMByUserEmail(userEmail)
+	if err != nil {
+		if err == orm.ErrNoRows {
+			return true, nil
+		} else {
+			return false, err
+		}
+	}
+	if (svm.Status == ACTIVE) || (svm.Status == INACTIVE) {
+		return true, nil
+	}
+	return false, nil
 }
 
 // Populates and returns a SCIONLabVMInfo struct, which contains the necessary information
@@ -202,7 +244,7 @@ func (s *SCIONLabVMController) updateDB(svmInfo *SCIONLabVMInfo) error {
 			IP:           svmInfo.IP,
 			IA:           new_as,
 			RemoteIAPort: svmInfo.RemotePort,
-			Activated:    false,
+			Status:       CREATE,
 			RemoteIA:     svmInfo.RemoteIA,
 		}
 		if err = new_svm.Insert(); err != nil {
@@ -211,6 +253,11 @@ func (s *SCIONLabVMController) updateDB(svmInfo *SCIONLabVMInfo) error {
 	} else {
 		// Update the SCIONLabVM Table
 		svmInfo.SVM.IP = svmInfo.IP
+		if svmInfo.SVM.Status == INACTIVE {
+			svmInfo.SVM.Status = CREATE
+		} else {
+			svmInfo.SVM.Status = UPDATE
+		}
 		if err := svmInfo.SVM.Update(); err != nil {
 			return fmt.Errorf("Error updating SCIONLabVM Table. User: %v, %v", svmInfo.UserEmail,
 				err)
@@ -350,17 +397,30 @@ func CopyFile(source string, dest string) (err error) {
 	return
 }
 
-type SCIONLabVMResp struct {
+// The struct used for API calls between scion-coord and SCIONLab ASes
+type SCIONLabVM struct {
 	ASID         string // ISD-AS of the VM
 	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
 	UserEmail    string // The email address of the user owning this SCIONLab VM AS
 	VMIP         string // IP address of the SCIONLab VM
+	RemoteBR     string // The name of the remote border router
 }
 
-// API end-point to serve the list of newly created but not yet activated SCIONLab VMs.
-// If successful, it returns an array of SCIONLabVMResp structs.
-func (s *SCIONLabVMController) GetNewSCIONLabVMASes(w http.ResponseWriter, r *http.Request) {
-	log.Printf("Inside GetNewSCIONLabVMASes = %v", r.URL.Query())
+// API end-point for the designated SCIONLab ASes to query actions to be done for users'
+// SCIONLab VM ASes.
+// An example response to this API may look like the following:
+// {"1-7":
+//        {"Create":[],
+//         "Remove":[],
+//         "Update":[{"ASID":"1-1020",
+//                    "RemoteIAPort":50053,
+//                    "UserEmail":"user@example.com",
+//                    "VMIP":"203.0.113.0",
+//                    "RemoteBR":"br1-5-5"}]
+//        }
+// }
+func (s *SCIONLabVMController) GetSCIONLabVMASes(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Inside GetSCIONLabVMASes = %v", r.URL.Query())
 	scionLabAS := r.URL.Query().Get("scionLabAS")
 	if len(scionLabAS) == 0 {
 		s.BadRequest(fmt.Errorf("scionLabAS parameter missing."), w, r)
@@ -372,18 +432,32 @@ func (s *SCIONLabVMController) GetNewSCIONLabVMASes(w http.ResponseWriter, r *ht
 		s.Error500(err, w, r)
 		return
 	}
-	vms_resp := []SCIONLabVMResp{}
+	vms_create_resp := []SCIONLabVM{}
+	vms_update_resp := []SCIONLabVM{}
+	vms_remove_resp := []SCIONLabVM{}
 	for _, v := range vms {
-		vm_resp := SCIONLabVMResp{
+		vm_resp := SCIONLabVM{
 			ASID:         strconv.Itoa(v.IA.Isd) + "-" + strconv.Itoa(v.IA.As),
 			VMIP:         v.IP,
 			RemoteIAPort: v.RemoteIAPort,
 			UserEmail:    v.UserEmail,
+			RemoteBR:     v.RemoteBR,
 		}
-		vms_resp = append(vms_resp, vm_resp)
+		switch v.Status {
+		case CREATE:
+			vms_create_resp = append(vms_create_resp, vm_resp)
+		case UPDATE:
+			vms_update_resp = append(vms_update_resp, vm_resp)
+		case REMOVE:
+			vms_remove_resp = append(vms_remove_resp, vm_resp)
+		}
 	}
-	resp := map[string][]SCIONLabVMResp{
-		scionLabAS: vms_resp,
+	resp := map[string]map[string][]SCIONLabVM{
+		scionLabAS: {
+			"Create": vms_create_resp,
+			"Update": vms_update_resp,
+			"Remove": vms_remove_resp,
+		},
 	}
 	b, err := json.Marshal(resp)
 	if err != nil {
@@ -394,35 +468,73 @@ func (s *SCIONLabVMController) GetNewSCIONLabVMASes(w http.ResponseWriter, r *ht
 	fmt.Fprintln(w, string(b))
 }
 
-// API end-point to mark the provided SCIONLabVMs as ACTIVE
-// If sucessful it returns and empty JSON response with HTTP code 200.
-func (s *SCIONLabVMController) ConfirmActivatedSCIONLabVMASes(w http.ResponseWriter, r *http.Request) {
-	log.Printf("Inside ConfirmActivatedSCIONLabVMASes..")
-	var ASIDs2VMIPs map[string][]string
+// API end-point to mark the provided SCIONLabVMs as Created, Updated or Removed
+// An example request to this API may look like the following:
+// {"1-7":
+//        {"Created":[],
+//         "Removed":[],
+//         "Updated":[{"ASID":"1-1020",
+//                     "RemoteIAPort":50053,
+//                     "VMIP":"203.0.113.0",
+//                     "RemoteBR":"br1-5-5"}]
+//        }
+// }
+// If sucessful, the API will return an empty JSON response with HTTP code 200.
+func (s *SCIONLabVMController) ConfirmSCIONLabVMASes(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Inside ConfirmSCIONLabVMASes..")
+	var ASIDs2VMs map[string]map[string][]SCIONLabVM
 	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&ASIDs2VMIPs); err != nil {
+	if err := decoder.Decode(&ASIDs2VMs); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
 		s.BadRequest(err, w, r)
 		return
 	}
-	for ia, vmIPs := range ASIDs2VMIPs {
-		for _, ip := range vmIPs {
-			// find the relevant SCIONLabVM and mark it as active.
-			vm, err := models.FindSCIONLabVMByIPAndIA(ip, ia)
-			if err != nil {
-				log.Printf("Error finding the SCIONLabVM with IP %v: %v", ip, err)
-				s.Error500(fmt.Errorf("Error finding the SCIONLabVM with IP %v: %v", ip, err), w, r)
-				return
-			}
-			vm.Activated = true
-			if err = vm.Update(); err != nil {
-				log.Printf("Error updating SCIONLabVM Table. VM IP: %v, %v", ip, err)
-				s.Error500(fmt.Errorf("Error updating SCIONLabVM Table. VM IP: %v, %v", ip, err),
-					w, r)
-			}
+	failedConfirmations := []string{}
+	for ia, event := range ASIDs2VMs {
+		for action, vms := range event {
+			failedConfirmations = append(failedConfirmations, s.processConfirmedSCIONLabVMASes(
+				ia, action, vms)...)
 		}
 	}
+	if len(failedConfirmations) > 0 {
+		s.Error500(fmt.Errorf("Error processing confirmations for the following VMs: %v",
+			failedConfirmations), w, r)
+		return
+	}
 	fmt.Fprintln(w, "{}")
+}
+
+// Updates the relevant DB tables based on the received confirmations from
+// SCIONLab AS.
+func (s *SCIONLabVMController) processConfirmedSCIONLabVMASes(ia, action string,
+	vms []SCIONLabVM) []string {
+	log.Printf("action = %v, vms = %v", action, vms)
+	failedConfirmations := []string{}
+	for _, vm := range vms {
+		// find the SCIONLabVM
+		vm_db, err := models.FindSCIONLabVMByIPAndRemoteIA(vm.VMIP, ia)
+		if err != nil {
+			log.Printf("Error finding the SCIONLabVM with IP %v: %v",
+				vm.VMIP, err)
+			failedConfirmations = append(failedConfirmations, vm.VMIP)
+		}
+		switch action {
+		case CREATED, UPDATED:
+			vm_db.Status = ACTIVE
+			vm_db.RemoteBR = vm.RemoteBR
+		case REMOVED:
+			vm_db.Status = INACTIVE
+			vm_db.RemoteBR = ""
+		default:
+			log.Printf("Unsupported VM action for: %v. User %v", vm.VMIP, vm_db.UserEmail)
+			failedConfirmations = append(failedConfirmations, vm.VMIP)
+		}
+		if err = vm_db.Update(); err != nil {
+			log.Printf("Error updating SCIONLabVM Table. VM IP: %v, %v", vm.VMIP, err)
+			failedConfirmations = append(failedConfirmations, vm.VMIP)
+		}
+	}
+	return failedConfirmations
 }
 
 // API end-point to serve the generated SCIONLab VM configuration tarball.
@@ -443,4 +555,52 @@ func (s *SCIONLabVMController) ReturnTarball(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Disposition", "attachment; filename=scion_lab_"+file_name)
 	w.Header().Set("Content-Transfer-Encoding", "binary")
 	http.ServeContent(w, r, "/api/as/downloads/"+file_name, time.Now(), bytes.NewReader(data))
+}
+
+// The handler function to remove a SCIONLab VM for the given user.
+// If successful, it will return a 200 status with an empty response.
+func (s *SCIONLabVMController) RemoveSCIONLabVM(w http.ResponseWriter, r *http.Request) {
+	// Parse the argument
+	if err := r.ParseForm(); err != nil {
+		log.Printf("Error parsing the form in RemoveSCIONLabVM: %v", err)
+		s.BadRequest(err, w, r)
+		return
+	}
+	userEmail := r.Form["userEmail"][0]
+	// check if there is an active VM which can be removed
+	canRemove, svm, err := s.canRemove(userEmail)
+	if err != nil {
+		log.Printf("Error checking if your VM can be removed. User: %v, %v", userEmail, err)
+		s.Error500(err, w, r)
+		return
+	}
+	if !canRemove {
+		s.BadRequest(fmt.Errorf("You currently do not have an active SCIONLab VM."), w, r)
+		return
+	}
+	svm.Status = REMOVE
+	if err := svm.Update(); err != nil {
+		s.Error500(fmt.Errorf("Error removing entry from SCIONLabVM Table. User: %v, %v",
+			userEmail, err), w, r)
+		return
+	}
+	log.Printf("Marked removal of SCIONLabVM of user %v.", userEmail)
+	fmt.Fprintln(w, "Your VM will be removed within the next 5 minutes.")
+}
+
+// Check if the user's VM is already removed or in the process of being removed.
+// Can remove a VM only if it is in the ACTIVE state.
+func (s *SCIONLabVMController) canRemove(userEmail string) (bool, *models.SCIONLabVM, error) {
+	svm, err := models.FindSCIONLabVMByUserEmail(userEmail)
+	if err != nil {
+		if err == orm.ErrNoRows {
+			return false, nil, nil
+		} else {
+			return false, nil, err
+		}
+	}
+	if svm.Status == ACTIVE {
+		return true, svm, nil
+	}
+	return false, nil, nil
 }

--- a/main.go
+++ b/main.go
@@ -71,11 +71,12 @@ func main() {
 	// generates a SCIONLab VM
 	// TODO(ercanucan): fix the authentication
 	router.Handle("/api/as/generateVM", apiChain.ThenFunc(scionLabVMController.GenerateSCIONLabVM))
+	router.Handle("/api/as/removeVM", apiChain.ThenFunc(scionLabVMController.RemoveSCIONLabVM))
 	router.Handle("/api/as/downloads", apiChain.ThenFunc(scionLabVMController.ReturnTarball))
-	router.Handle("/api/as/getNewSCIONLabVMASes/{account_id}/{secret}",
-		apiChain.ThenFunc(scionLabVMController.GetNewSCIONLabVMASes))
-	router.Handle("/api/as/confirmActivatedSCIONLabVMASes/{account_id}/{secret}",
-		apiChain.ThenFunc(scionLabVMController.ConfirmActivatedSCIONLabVMASes))
+	router.Handle("/api/as/getSCIONLabVMASes/{account_id}/{secret}",
+		apiChain.ThenFunc(scionLabVMController.GetSCIONLabVMASes))
+	router.Handle("/api/as/confirmSCIONLabVMASes/{account_id}/{secret}",
+		apiChain.ThenFunc(scionLabVMController.ConfirmSCIONLabVMASes))
 
 	// ==========================================================
 	// SCION Web API

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -45,7 +45,7 @@ type SCIONLabVM struct {
 	RemoteIA     string // the SCIONLab AS it connects to
 	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
 	RemoteBR     string // the name of the remote border router for this AS
-	Status       string // Action to be taken for this VM (i.e Active, Create, Update, Remove)
+	Status       uint8  `orm:"default(0)"` // Status of the VM (i.e Active, Create, Update, Remove)
 }
 
 func FindSCIONLabVMByUserEmail(email string) (*SCIONLabVM, error) {

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -44,7 +44,8 @@ type SCIONLabVM struct {
 	IA           *As    `orm:"rel(fk);index"` // The AS belonging to the VM
 	RemoteIA     string // the SCIONLab AS it connects to
 	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
-	Activated    bool
+	RemoteBR     string // the name of the remote border router for this AS
+	Status       string // Action to be taken for this VM (i.e Active, Create, Update, Remove)
 }
 
 func FindSCIONLabVMByUserEmail(email string) (*SCIONLabVM, error) {
@@ -53,7 +54,7 @@ func FindSCIONLabVMByUserEmail(email string) (*SCIONLabVM, error) {
 	return v, err
 }
 
-func FindSCIONLabVMByIPAndIA(ip, ia string) (*SCIONLabVM, error) {
+func FindSCIONLabVMByIPAndRemoteIA(ip, ia string) (*SCIONLabVM, error) {
 	v := new(SCIONLabVM)
 	err := o.QueryTable(v).Filter("IP", ip).Filter("RemoteIA", ia).RelatedSel().One(v)
 	return v, err
@@ -62,7 +63,7 @@ func FindSCIONLabVMByIPAndIA(ip, ia string) (*SCIONLabVM, error) {
 func FindSCIONLabVMsByRemoteIA(remoteIA string) ([]SCIONLabVM, error) {
 	var v []SCIONLabVM
 	// TODO (ercanucan): Find a better way to refer to the database table without absolute name
-	_, err := o.QueryTable("s_c_i_o_n_lab_v_m").Filter("RemoteIA", remoteIA).Filter("Activated", false).RelatedSel().All(&v)
+	_, err := o.QueryTable("s_c_i_o_n_lab_v_m").Filter("RemoteIA", remoteIA).RelatedSel().All(&v)
 	return v, err
 }
 

--- a/public/js/controllers/admin.js
+++ b/public/js/controllers/admin.js
@@ -2,6 +2,9 @@ angular.module('scionApp')
     .controller('adminCtrl', ['$scope', 'adminService', '$location', '$window', '$http',
         function($scope, adminService, $location, $window, $http) {
 
+            $scope.error = "";
+            $scope.message = "";
+
             $scope.me = function() {
 
                 adminService.me().then(
@@ -15,22 +18,38 @@ angular.module('scionApp')
                     });
             };
 
-
-            // refresh the data when the controller is loaded
-            $scope.me();
-
-            $scope.scionLabVM = function(user) {
+            $scope.generateSCIONLabVM = function(user) {
                 $scope.error = "";
+                $scope.message = "";
 
-                adminService.scionLabVM(user).then(
+                adminService.generateSCIONLabVM(user).then(
                     function(data) {
                         console.log(data);
                         window.location.assign('/api/as/downloads?filename=' + data);
+                        $scope.message = "Your VM will be activated within a few minutes.";
                     },
                     function(response) {
                         console.log(response);
                         $scope.error = response.data;
                     });
             };
+
+            $scope.removeSCIONLabVM = function(user) {
+                $scope.error = "";
+                $scope.message = "";
+
+                adminService.removeSCIONLabVM(user).then(
+                    function(data) {
+                        console.log(data);
+                        $scope.message = data;
+                    },
+                    function(response) {
+                        console.log(response);
+                        $scope.error = response.data;
+                    });
+            };
+
+            // refresh the data when the controller is loaded
+            $scope.me();
      }
     ]);

--- a/public/js/services/admin.js
+++ b/public/js/services/admin.js
@@ -12,7 +12,7 @@ angular.module('scionApp')
             });
         },
         // Create SCIONLab VM
-        scionLabVM: function(user) {
+        generateSCIONLabVM: function(user) {
             // $http returns a promise, which has a then function, which also returns a promise
             // TODO(ercanucan): compose the URL in a cleaner fashion
             var url = '/api/as/generateVM?scionLabVMIP=' + user.scionLabVMIP + "&userEmail=" + user.Email;
@@ -23,6 +23,18 @@ angular.module('scionApp')
                 return response.data;
             });
         },
+        // Remove SCIONLab VM
+        removeSCIONLabVM: function(user) {
+            // $http returns a promise, which has a then function, which also returns a promise
+            console.log("Inside remove VM");
+            var url = '/api/as/removeVM?userEmail=' + user.Email;
+            return $http.post(url).then(function (response) {
+                // The then function here is an opportunity to modify the response
+                console.log(response);
+                // The return value gets picked up by the then in the controller.
+                return response.data;
+            });
+        }
     };
     return adminService;
 }]);

--- a/public/partials/admin.html
+++ b/public/partials/admin.html
@@ -7,7 +7,12 @@
 
   <p><b>AccountId:</b> {{user.AccountId}}</p>
   <p><b>Secret:</b> {{user.Secret}}</p>
-
+  <div ng-show="error" ng-model="error" class="alert alert-danger alert-dismissible">
+    {{error}}
+  </div>
+  <div ng-if="message" class="alert alert-success alert-dismissible">
+    {{message}}
+  </div>
   <br/>
   <br/>
   <p><font color="red">When you fill out and submit the form below, your SCIONLab VM configuration for connecting to SCIONLab AS 1-7 will be packaged
@@ -15,19 +20,21 @@
 
   <p><font color="red"><b>Please note:</b> SCIONLab currently requires that your machine has a public IP address and can receive UDP traffic at port 50000.</font></p>
 
-  <form name="scionLabVMForm" ng-submit="scionLabVM(user)">
+  <form name="scionLabVMForm" ng-submit="generateSCIONLabVM(user)">
     <div class="form-group has-feedback">
       <input type="text" class="form-control" ng-model="user.scionLabVMIP" name="scionLabVMIP" placeholder="My host's public IP address" ng-required="true">
       <span class="form-control-feedback"></span>
     </div>
     <div class="row">
       <div class="col-xs-12">
-        <button type="submit" class="btn btn-primary btn-block btn-flat">Create and Download SCIONLab VM Configuration</button>
+        <button type="submit" class="btn btn-primary btn-block btn-flat">Create/Update and Download SCIONLab VM Configuration</button>
       </div>
-      <!-- /.col -->
     </div>
-    <div ng-show="error" ng-model="error" class="alert alert-danger alert-dismissible">
-      {{error}}
+    <br/>
+    <div class="row">
+      <div class="col-xs-12">
+        <button ng-click="removeSCIONLabVM(user)" type="button" class="btn btn-primary btn-block btn-flat">Remove my SCIONLab VM</button>
+      </div>
     </div>
   </form>
 


### PR DESCRIPTION
This change adds the back-end APIs and front-end (UI) for a user to create, update and remove his SCIONLab VM.
- Introduces various states in the DB for a user's VM such as ACTIVE, INACTIVE, CREATE, UPDATE, REMOVE.
- In order avoid certain race condtions, the change enforces that a user cannot give multiple commands while there is an ongoing operation on his VM such as UPDATE, CREATE or REMOVE.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/55)
<!-- Reviewable:end -->
