### PR TITLE
Added directories `credentials` and `temp`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 scion-coord
 vendor/*/
+temp/
+credentials/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ SCION Coordination service
 
 ### How to run it
 
+#### Dependencies
+
 The application uses govendor. You need to install govendor via:
 `go get github.com/kardianos/govendor`
 
@@ -22,13 +24,7 @@ Secret key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 Warning: Use above keys only for testing purposes as they circumvent the captcha.
 
 
-Afterwards, you can run `go run main.go` from the root folder.
-Otherwise you can also run the application via:
-
-```
-go build
-./scion-coord
-```
+#### MySQL database
 
 Important:
 The project needs a working MySQL server instance running locally. You can
@@ -47,7 +43,32 @@ and then executing the following command:
 
 `CREATE DATABASE scion_coord_test;`
 
+
+#### Custom settings
+
 You can change the settings in the config file located at: `conf/development.conf`
+
+
+#### Credentials
+
+In order for the configurations to be generated, the following files must exist:
+```
+credentials/ISD1-AS1-V0.crt
+credentials/as-sig.key
+credentials/ISD1-V0.trc
+```
+
+
+#### Run scion-coord
+
+
+Afterwards, you can run `go run main.go` from the root folder.
+Otherwise you can also run the application via:
+
+```
+go build
+./scion-coord
+```
 
 
 ### Current APIs

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -28,6 +29,20 @@ import (
 )
 
 func main() {
+	// check if credential files exist and create necessary directories
+	for _, f := range []string{api.TrcFile, api.CoreCertFile, api.CoreSigKey} {
+		if _, err := os.Stat(f); err != nil {
+			if os.IsNotExist(err) {
+				fmt.Println("ERROR: Please make sure that the necessary credential files exist.")
+				fmt.Println("Consult the README.md for further details.")
+			} else {
+				fmt.Println("An error occurred when accessing " + f + ".")
+			}
+			return
+		}
+	}
+	os.MkdirAll(api.TempPath, os.ModePerm)
+	os.MkdirAll(api.PackagePath, os.ModePerm)
 
 	// controllers
 	registrationController := api.RegistrationController{}


### PR DESCRIPTION
Store keys and certificates in directory `credentials`, the content of which will be ignored by git, instead of `python`. Also add directory `temp` where the default topology and files generated for users will be stored (instead of `~/scionLabConfigs`), this is also ignored by git.
This PR also fixes a potential problem of a non-standard GOPATH.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/56)
<!-- Reviewable:end -->
