### PR TITLE
Fix for "user already verified" with HTTP HEAD requests

### DIFF
--- a/controllers/api/register.go
+++ b/controllers/api/register.go
@@ -90,17 +90,15 @@ func (c *RegistrationController) VerifyEmail(w http.ResponseWriter, r *http.Requ
 	}
 
 	if u.Verified {
-		log.Printf("Error verifying email address. User %v is already verified.", u.Email)
-		c.BadRequest(fmt.Errorf("The email %v is already verified. Please continue to the login page.", u.Email), w, r)
-		return
-	}
-
-	// update user
-	if err := u.UpdateVerified(true); err != nil {
-		log.Printf("Error verifying email address for user %v: %v.", u.Email, err)
-		// TODO: Pass the user a unique error ID which links to the specific error and allows for debugging
-		c.Error500(fmt.Errorf("Error verifying email address for user %v.", u.Email), w, r)
-		return
+		log.Printf("User %v is already verified.", u.Email)
+	} else {
+		// update user
+		if err := u.UpdateVerified(true); err != nil {
+			log.Printf("Error verifying email address for user %v: %v.", u.Email, err)
+			// TODO: Pass the user a unique error ID which links to the specific error and allows for debugging
+			c.Error500(fmt.Errorf("Error verifying email address for user %v.", u.Email), w, r)
+			return
+		}
 	}
 
 	// load validation page


### PR DESCRIPTION
Some browsers send HTTP HEAD requests before GET requests to save some bandwidth. In this case, the first request triggered the activation such that a "user already verified" error was displayed to the user.
This is fixed, by simply displaying the "success" page even if the user was already verified and only logging the error for debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/64)
<!-- Reviewable:end -->
