### PR TITLE
Add option to use OpenVPN-based connection to SCIONLab AS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ SCIONLab Coordination service
 
 ##### Setup go, scion, and scion-coord
 
-Make sure that you have `go` and `python3` installed. Then, follow instructions 2 and 3 at https://github.com/netsec-ethz/scion.
+Make sure that you have `go` and `python3` installed. Then, follow instructions 2 and 3 at 
+https://github.com/netsec-ethz/scion.
 
-Then, download this repository either by cloning it or by using `go get github.com/netsec-ethz/scion-coord`.
+Then, download this repository either by cloning it or by using 
+`go get github.com/netsec-ethz/scion-coord`.
 
 
 ##### Go dependencies
@@ -17,34 +19,33 @@ Then, download this repository either by cloning it or by using `go get github.c
 The application uses govendor. You need to install govendor via:
 `go get github.com/kardianos/govendor`
 
-After this step, you can go to the `scion-coord` directory (`$GOPATH/src/github.com/netsec-ethz/scion-coord`) and populate the dependencies in the `vendor` folder using:
-`govendor sync`
+After this step, you can go to the `scion-coord` directory 
+(`$GOPATH/src/github.com/netsec-ethz/scion-coord`) and populate the dependencies in the `vendor` 
+folder using `govendor sync`.
 
 
 #### Custom configuration
 
-Copy the default configuration file using
-`cp conf/development.conf.default conf/development.conf`
+Copy the default configuration file using `cp conf/development.conf.default conf/development.conf`
 and adjust the settings to fit your setup.
-Make sure that you set `email.pm_server_token`, `email.pm_account_token`, `captcha.site_key`, and `captcha.secret_key` as described below.
+Make sure that you set `email.pm_server_token`, `email.pm_account_token`, `captcha.site_key`, and 
+`captcha.secret_key` as described below.
 
 
 ##### Postmark
 
-SCIONLab Coordination service uses [Postmark](https://postmarkapp.com/ "Postmark") to send emails. You will need an account token and a server token which are obtained by signing up to their service.
+SCIONLab Coordination service uses [Postmark](https://postmarkapp.com/ "Postmark") to send emails. 
+You will need an account token and a server token which are obtained by signing up to their service.
 Set the corresponding fields in the configuration file accordingly.
 
 
 ##### Captcha
 
-In the configuration file also populate the captcha fields with the keys generated [on this site](https://www.google.com/recaptcha/admin "Google ReCaptcha admin page").
-For a quick start and for testing these keys can be used:
+In the configuration file also populate the captcha fields with the keys generated 
+[on this site](https://www.google.com/recaptcha/admin "Google ReCaptcha admin page").
+For a quick start and for testing the keys in the `development.conf.default` can be used.
 
-```
-Site key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-Secret key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
-```
-Warning: Use above keys only for testing purposes as they circumvent the captcha.
+Warning: Use these keys only for testing purposes as they circumvent the captcha.
 
 
 #### MySQL database
@@ -76,11 +77,46 @@ credentials/ISD1-V0.trc
 ```
 
 
+#### Certificate authority setup
+
+In order to use OpenVPN inside the generated SCIONLab VMs, it is necessary to set up a certificate 
+authority. We use the tool `easy-rsa` for this.
+
+Install `easy-rsa` (version 2.x) using your package manager or download it from the 
+[github repository](https://github.com/OpenVPN/easy-rsa/tree/release/2.x "easy-rsa").
+
+Copy the `easy-rsa` directory to the PACKAGE_DIRECTORY (we assume you are using the default 
+`~/scionLabConfigs`). If you installed it via the package manager, you can usually do this by 
+```
+mkdir -p ~/scionLabConfigs
+cp -r /usr/share/easy-rsa ~/scionLabConfigs
+```
+
+Now, copy the default configuration `cp conf/easy-rsa_vars.default ~/scionLabConfigs/easy-rsa/vars` 
+and adjust the parameters if necessary. You may have to specify the openssl executable (be sure to 
+use openssl 0.9.6, 0.9.8, or 1.0.x).
+Now you can initialize your certificate authority by issuing (use the default for all prompts):
+```
+cd ~/scionLabConfigs/easy-rsa
+source vars
+./clean-all
+./build-ca
+```
+
+In order to setup OpenVPN on the server machine, generate keys using
+```
+./build-key-server myservername
+./build-dh
+```
+Then, you have to transfer files `ca.crt`, `myservername.crt`, `myservername.key`, and `dh4096.pem` 
+located in the `keys` directory to the machine running the OpenVPN server. You should delete 
+the server key from this machine.
+
+
 ### Run scion-coord
 
 Afterwards, you can run `go run main.go` from the root folder.
 Otherwise you can also run the application via:
-
 ```
 go build
 ./scion-coord

--- a/conf/development.conf.default
+++ b/conf/development.conf.default
@@ -12,17 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# If uncommented and non-empty it switches logging from
-# console to a file
+# File and directory overwrites
+# If uncommented and non-empty it switches logging from console to a file
 #log.file = ""
+
+# If uncommented and non-empty, this directory is used to store generated
+# VM configurations instead of "~/scionLabConfigs"
+#directory.package_directory = ""
 
 # Address and port to listen to incoming requests
 http.bind_address = "127.0.0.1"
 http.bind_port = 8080
 
 # Address visible from outside
-#http.host_address = "coord.scionproto.net"
-http.host_address = "127.0.0.1:8080"
+http.host_address = "localhost:8080"
 
 # PostMark email service configs
 email.from = "no-reply@scionlab.org"
@@ -30,15 +33,16 @@ email.pm_server_token = ""
 email.pm_account_token = ""
 
 # Captcha configs
-captcha.site_key = ""
-captcha.secret_key = ""
+captcha.site_key = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+captcha.secret_key = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
 
 # Session configs
 session.path = "/tmp"
 session.encryption_key = "x290jdxmcam9q2dci:LWC92cqwop,0rt"
 session.verification_key = "c23omc2o,pb45,-34l=12ms21odmx1;f"
 
-# Database configs: at the moment only MySQL is supported, although it could be easy to support others
+# Database configs: at the moment only MySQL is supported, although it could be easy to support
+# others
 db.name = "scion_coord_test"
 db.host = "127.0.0.1"
 db.port = 3306
@@ -46,3 +50,12 @@ db.user = "root"
 db.pass = "development_pass"
 db.max_connections = 15
 db.max_idle = 3
+
+# SCIONLab AS configs
+server.ia = "1-7"
+server.ip = "127.0.0.1"
+server.start_port = "50050"
+server.vpn.ip = "10.0.8.1"
+server.vpn.start_ip = "10.0.8.2"
+server.vpn.end_ip = "10.0.8.254"
+server.vpn.start_port = "50050"

--- a/conf/easy-rsa_vars.default
+++ b/conf/easy-rsa_vars.default
@@ -1,0 +1,72 @@
+# easy-rsa parameter settings
+
+# NOTE: If you installed from an RPM,
+# don't edit this file in place in
+# /usr/share/openvpn/easy-rsa --
+# instead, you should copy the whole
+# easy-rsa directory to another location
+# (such as /etc/openvpn) so that your
+# edits will not be wiped out by a future
+# OpenVPN package upgrade.
+
+# This variable should point to
+# the top level of the easy-rsa
+# tree.
+export EASY_RSA="`pwd`"
+
+#
+# This variable should point to
+# the requested executables
+#
+export OPENSSL="openssl"
+export PKCS11TOOL="pkcs11-tool"
+export GREP="grep"
+
+# This variable should point to
+# the openssl.cnf file included
+# with easy-rsa.
+export KEY_CONFIG=`$EASY_RSA/whichopensslcnf $EASY_RSA`
+
+# Edit this variable to point to
+# your soon-to-be-created key
+# directory.
+#
+# WARNING: clean-all will do
+# a rm -rf on this directory
+# so make sure you define
+# it correctly!
+export KEY_DIR="$EASY_RSA/keys"
+
+# Issue rm -rf warning
+echo NOTE: If you run ./clean-all, I will be doing a rm -rf on $KEY_DIR
+
+# PKCS11 fixes
+export PKCS11_MODULE_PATH="dummy"
+export PKCS11_PIN="dummy"
+
+# Increase this to 2048 if you
+# are paranoid.  This will slow
+# down TLS negotiation performance
+# as well as the one-time DH parms
+# generation process.
+export KEY_SIZE=4096
+
+# In how many days should the root CA key expire?
+export CA_EXPIRE=1000
+
+# In how many days should certificates expire?
+export KEY_EXPIRE=730
+
+# These are the default values for fields
+# which will be placed in the certificate.
+# Don't leave any of these fields blank.
+export KEY_COUNTRY="CH"
+export KEY_PROVINCE="ZH"
+export KEY_CITY="Zurich"
+export KEY_ORG="ETH"
+export KEY_EMAIL="scion@lists.inf.ethz.ch"
+export KEY_OU="NetSec"
+
+# X509 Subject Field
+export KEY_NAME="SCIONVPN"
+export KEY_ALTNAMES="SCIONVPN"

--- a/config/config.go
+++ b/config/config.go
@@ -15,14 +15,20 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/sec51/goconf"
 )
 
 // Settings are specified in conf/development.conf
 var (
-	HTTP_BIND_ADDRESS        = goconf.AppConf.String("http.bind_address") // address the service listens on
-	HTTP_BIND_PORT, _        = goconf.AppConf.Int("http.bind_port")       // port the service listens on
-	HTTP_HOST_ADDRESS        = goconf.AppConf.String("http.host_address") // address from which the service is reachable from outside
+	// address the service listens on
+	HTTP_BIND_ADDRESS = goconf.AppConf.String("http.bind_address")
+	// port the service listens on
+	HTTP_BIND_PORT, _ = goconf.AppConf.Int("http.bind_port")
+	// address from which the service is reachable from outside
+	HTTP_HOST_ADDRESS        = goconf.AppConf.String("http.host_address")
 	EMAIL_PM_SERVER_TOKEN    = goconf.AppConf.String("email.pm_server_token")
 	EMAIL_PM_ACCOUNT_TOKEN   = goconf.AppConf.String("email.pm_account_token")
 	EMAIL_FROM               = goconf.AppConf.String("email.from")
@@ -32,6 +38,8 @@ var (
 	SESSION_ENCRYPTION_KEY   = goconf.AppConf.String("session.encryption_key")
 	SESSION_VERIFICATION_KEY = goconf.AppConf.String("session.verification_key")
 	LOG_FILE                 = goconf.AppConf.String("log.file")
+	PACKAGE_DIRECTORY        = goconf.AppConf.DefaultString("directory.package_directory",
+		filepath.Join(os.Getenv("HOME"), "scionLabConfigs"))
 	DB_NAME                  = goconf.AppConf.String("db.name")
 	DB_HOST                  = goconf.AppConf.String("db.host")
 	DB_PORT, _               = goconf.AppConf.Int("db.port")
@@ -39,4 +47,11 @@ var (
 	DB_PASS                  = goconf.AppConf.String("db.pass")
 	DB_MAX_CONNECTIONS, _    = goconf.AppConf.Int("db.max_connections")
 	DB_MAX_IDLE, _           = goconf.AppConf.Int("db.max_idle")
+	SERVER_IA                = goconf.AppConf.String("server.ia")
+	SERVER_IP                = goconf.AppConf.String("server.ip")
+	SERVER_START_PORT, _     = goconf.AppConf.Int("server.start_port")
+	SERVER_VPN_IP            = goconf.AppConf.String("server.vpn.ip")
+	SERVER_VPN_START_IP      = goconf.AppConf.String("server.vpn.start_ip")
+	SERVER_VPN_END_IP        = goconf.AppConf.String("server.vpn.end_ip")
+	SERVER_VPN_START_PORT, _ = goconf.AppConf.Int("server.vpn.start_port")
 )

--- a/controllers/api/scion_lab_vpn.go
+++ b/controllers/api/scion_lab_vpn.go
@@ -1,0 +1,103 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// Generates client keys and configuration necessary for a VPN-based setup
+func (s *SCIONLabVMController) generateVPNConfig(svmInfo *SCIONLabVMInfo) error {
+	log.Printf("Creating VPN config for SCIONLab VM")
+	if err := s.generateVPNKeys(svmInfo); err != nil {
+		return err
+	}
+	t, err := template.ParseFiles("templates/client.conf.tmpl")
+	if err != nil {
+		return fmt.Errorf("Error parsing VPN template config: %v", err)
+	}
+
+	var caCert, clientCert, clientKey []byte
+	caCert, err = ioutil.ReadFile(CACertPath)
+	if err != nil {
+		return fmt.Errorf("Error reading CA certificate file: %v", err)
+	}
+	clientCert, err = ioutil.ReadFile(filepath.Join(RSAKeyPath, svmInfo.UserEmail+".crt"))
+	if err != nil {
+		return fmt.Errorf("Error reading VPN certificate file for user %v: %v",
+			svmInfo.UserEmail, err)
+	}
+	clientCertStr := string(clientCert)
+	startCert := strings.Index(clientCertStr, "-----BEGIN CERTIFICATE-----")
+	clientKey, err = ioutil.ReadFile(filepath.Join(RSAKeyPath, svmInfo.UserEmail+".key"))
+	if err != nil {
+		return fmt.Errorf("Error reading VPN key file for user %v: %v",
+			svmInfo.UserEmail, err)
+	}
+
+	config := map[string]string{
+		"ServerIP":   svmInfo.VPNIP,
+		"CACert":     string(caCert),
+		"ClientCert": clientCertStr[startCert:],
+		"ClientKey":  string(clientKey),
+	}
+	f, err := os.Create(filepath.Join(UserPackagePath(svmInfo.UserEmail), "client.conf"))
+	if err != nil {
+		return fmt.Errorf("Error creating VPN config file for user %v: %v", svmInfo.UserEmail, err)
+	}
+	if err = t.Execute(f, config); err != nil {
+		return fmt.Errorf("Error executing VPN template file for user %v: %v",
+			svmInfo.UserEmail, err)
+	}
+	return nil
+}
+
+// Creates the keys for VPN setup
+func (s *SCIONLabVMController) generateVPNKeys(svmInfo *SCIONLabVMInfo) error {
+	log.Printf("Generating RSA keys")
+	if _, err := os.Stat(filepath.Join(RSAKeyPath, svmInfo.UserEmail+".key")); err == nil {
+		log.Printf("Previous VPN keys exist")
+	} else if os.IsNotExist(err) {
+		cmd := exec.Command("/bin/bash", "-c", "source vars; ./build-key --batch "+
+			svmInfo.UserEmail)
+		cmd.Dir = EasyRSAPath
+		cmdOut, _ := cmd.StdoutPipe()
+		cmdErr, _ := cmd.StderrPipe()
+		if err := cmd.Run(); err != nil {
+			log.Printf("Error during generation of VPN keys for user %v: %v", svmInfo.UserEmail,
+				err)
+			return err
+		}
+
+		// read stdout and stderr
+		stdOutput, _ := ioutil.ReadAll(cmdOut)
+		errOutput, _ := ioutil.ReadAll(cmdErr)
+		fmt.Printf("STDOUT generateVPNKeys: %s\n", stdOutput)
+		fmt.Printf("ERROUT generateVPNKeys: %s\n", errOutput)
+	} else {
+		log.Printf("Error checking for existence of VPN keys for user %v: %v", svmInfo.UserEmail,
+			err)
+		return err
+	}
+
+	return nil
+}

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -28,6 +28,7 @@ type vmInfo struct {
 	VMText   string
 	VMIP     string
 	ShowIP   bool
+	ShowVPN  bool
 }
 
 type buttonConfiguration struct {
@@ -105,7 +106,11 @@ func populateVMStatusButtons(userEmail string) (vmInfo, uiButtons, error) {
 		buttons.Download.Disable = true
 	}
 	if vmInfo.VMStatus == ACTIVE || vmInfo.VMStatus == CREATE || vmInfo.VMStatus == UPDATE {
-		vmInfo.ShowIP = true
+		if vm.IsVPN {
+			vmInfo.ShowVPN = true
+		} else {
+			vmInfo.ShowIP = true
+		}
 	}
 
 	return vmInfo, buttons, nil

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -15,10 +15,13 @@
 package models
 
 type SCIONLabServer struct {
-	Id               uint64 `orm:"column(id);auto;pk"`
-	IA               string `orm:"unique"` // ISD-AS in which the server is located
-	IP               string // IP address of the machine
-	LastAssignedPort int    // the last given out port number
+	Id                  uint64 `orm:"column(id);auto;pk"`
+	IA                  string `orm:"unique"` // ISD-AS in which the server is located
+	IP                  string // IP address of the machine
+	LastAssignedPort    int    // the last given out port number
+	VPNIP               string // IP address of the machine inside the VPN
+	VPNLastAssignedIP   string // the last given out IP address for the VPN
+	VPNLastAssignedPort int    // the last given out port number inside the VPN
 }
 
 func (sls *SCIONLabServer) Insert() error {
@@ -42,10 +45,11 @@ type SCIONLabVM struct {
 	UserEmail    string `orm:"unique"`        // Email address of the Owning user
 	IP           string `orm:"unique"`        // IP address of the SCIONLab VM
 	IA           *As    `orm:"rel(fk);index"` // The AS belonging to the VM
-	RemoteIA     string // the SCIONLab AS it connects to
-	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
-	RemoteBR     string // the name of the remote border router for this AS
-	Status       uint8  `orm:"default(0)"` // Status of the VM (i.e Active, Create, Update, Remove)
+	IsVPN        bool                         // is this VM connected via the VPN
+	RemoteIA     string                       // the SCIONLab AS it connects to
+	RemoteIAPort int                          // port number of the remote SCIONLab AS being connected to
+	RemoteBR     string                       // the name of the remote border router for this AS
+	Status       uint8  `orm:"default(0)"`    // Status of the VM (i.e Active, Create, Update, Remove)
 }
 
 func FindSCIONLabVMByUserEmail(email string) (*SCIONLabVM, error) {
@@ -62,8 +66,7 @@ func FindSCIONLabVMByIPAndRemoteIA(ip, ia string) (*SCIONLabVM, error) {
 
 func FindSCIONLabVMsByRemoteIA(remoteIA string) ([]SCIONLabVM, error) {
 	var v []SCIONLabVM
-	// TODO (ercanucan): Find a better way to refer to the database table without absolute name
-	_, err := o.QueryTable("s_c_i_o_n_lab_v_m").Filter("RemoteIA", remoteIA).RelatedSel().All(&v)
+	_, err := o.QueryTable(new(SCIONLabVM)).Filter("RemoteIA", remoteIA).RelatedSel().All(&v)
 	return v, err
 }
 

--- a/public/js/controllers/user.js
+++ b/public/js/controllers/user.js
@@ -12,7 +12,8 @@ scionApp
                         console.log(data);
                         $scope.user = data["User"];
                         $scope.vmInfo = data["VMInfo"];
-                        $scope.buttonConfig = data["UIButtons"]
+                        $scope.buttonConfig = data["UIButtons"];
+                        $scope.user.isNotVPN = false;
                     },
                     function (response) {
                         console.log(response);
@@ -25,8 +26,10 @@ scionApp
             $scope.submitForm = function (action, user) {
                 switch (action) {
                     case "update":
-                        $scope.scionLabVMForm.scionLabVMIP.$setValidity("required", user.scionLabVMIP != null);
-                        if (!$scope.scionLabVMForm.scionLabVMIP.$valid) {
+                        if (user.isNotVPN) {
+                            $scope.scionLabVMForm.scionLabVMIP.$setValidity("required", user.scionLabVMIP != null);
+                        }
+                        if (user.isNotVPN && !$scope.scionLabVMForm.scionLabVMIP.$valid) {
                             $scope.error = "Please enter a correct public IP address.";
                         } else {
                             $scope.generateSCIONLabVM(user);

--- a/public/js/services/user.js
+++ b/public/js/services/user.js
@@ -15,7 +15,7 @@ scionApp
         generateSCIONLabVM: function (user) {
             // $http returns a promise, which has a then function, which also returns a promise
             // TODO(ercanucan): compose the URL in a cleaner fashion
-            var url = '/api/as/generateVM?scionLabVMIP=' + user.scionLabVMIP + "&userEmail=" + user.Email;
+            var url = '/api/as/generateVM?isVPN=' + (!user.isNotVPN) + '&scionLabVMIP=' + user.scionLabVMIP + "&userEmail=" + user.Email;
             return $http.post(url).then(function (response) {
                 // The then function here is an opportunity to modify the response
                 console.log(response);

--- a/public/partials/user.html
+++ b/public/partials/user.html
@@ -7,47 +7,65 @@
 
   <p><strong>AccountId:</strong> {{user.AccountID}}</p>
   <p><strong>Secret:</strong> {{user.Secret}}</p>
-  <div class="alert alert-info"><p>{{vmInfo.VMText}} <span ng-if="vmInfo.ShowIP">Your registered IP address is <strong>{{vmInfo.VMIP}}</strong>.</span>
-  </p></div>
-
+  <div class="alert alert-info">
+    <p>{{vmInfo.VMText}} <span
+        ng-if="vmInfo.ShowIP">Your registered IP address is <strong>{{vmInfo.VMIP}}</strong>.</span>
+      <span ng-if="vmInfo.ShowVPN">You have chosen a <strong>VPN-based</strong> setup.</span>
+    </p>
+  </div>
   <div style="color:red">
-    <p>When you fill out and submit the form below, your SCIONLab VM configuration for
-      connecting to SCIONLab AS 1-7 will be packaged and downloaded. Please extract the
-      downloaded tarball in a desired location and refer to the README file inside for instructions.</p>
-    <p><b>Please note:</b> SCIONLab currently requires that your machine has a public
-      IP address and can receive UDP traffic at port 50000.</p></div>
+    <p>When you fill out and submit the form below, your SCIONLab VM configuration
+      for connecting to the designated SCIONLab AS will be packaged and downloaded.
+      Please extract the downloaded tarball in a desired location and refer to the
+      README file inside for instructions.</p>
+    <p>If you have a static public IP address and can receive traffic at port 50000, the border
+      router listens on the public IP address. Otherwise, a vpn-based setup is set up for you,
+      such that you do not need to apply any further configuration.</p>
+  </div>
   <br/>
 
   <form name="scionLabVMForm">
     <div class="form-group has-feedback">
-      <input type="text" class="form-control required" ng-model="user.scionLabVMIP"
-             name="scionLabVMIP" placeholder="My host's public IP address"
-             ng-disabled="buttonConfig.Update.Disable" data-toggle="tooltip"
-             title="{{buttonConfig.Update.Disable ? buttonConfig.Update.TooltipDisabled : ''}}" ng-pattern="/^(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/">
+      <label class="btn btn-block btn-primary" ng-disabled="buttonConfig.Update.Disable"
+             data-toggle="tooltip"
+             title="{{buttonConfig.Update.Disable ? buttonConfig.Update.TooltipDisabled :
+             'If you do not have a static public IP address, a vpn-based setup will be ' +
+             'configured for you.'}}">
+        <input type="checkbox" ng-model="user.isNotVPN" name="isNotVPN"
+               ng-disabled="buttonConfig.Update.Disable">
+        My host has a static public IP address and can receive traffic at port 50000.</label>
+
+      <input type="text" class="form-control" ng-model="user.scionLabVMIP" name="scionLabVMIP"
+             placeholder="My host's public IP address" ng-if="user.isNotVPN"
+             ng-pattern="/^(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/">
       <span class="form-control-feedback"></span>
     </div>
     <div class="row">
       <div class="col-xs-12">
-        <div id="buttongroup" ng-class="{true:'btn-group-vertical btn-block', false:'btn-group btn-group-justified'}[isSmall]">
+        <div id="buttongroup" ng-class="{true:'btn-group-vertical btn-block',
+        false:'btn-group btn-group-justified'}[isSmall]">
           <!--<div ng-repeat="button in buttonConfig">-->
-            <div ng-repeat="button in buttonConfig" class="btn-group" role="group" ng-if="button.Hide == false">
-              <button ng-click="submitForm(button.Action, user)" ng-disabled="button.Disable"
-                      class="btn btn-primary {{button.Class}}" data-toggle="tooltip"
-                      title="{{button.Disable ? button.TooltipDisabled : ''}}">
-                {{button.Text}}
-              </button>
-            </div>
+          <div ng-repeat="button in buttonConfig" class="btn-group" role="group"
+               ng-if="button.Hide == false">
+            <button ng-click="submitForm(button.Action, user)" ng-disabled="button.Disable"
+                    class="btn btn-primary {{button.Class}}" data-toggle="tooltip"
+                    title="{{button.Disable ? button.TooltipDisabled : ''}}">
+              {{button.Text}}
+            </button>
+          </div>
         </div>
       </div>
     </div>
   </form>
   <br/>
   <div ng-show="error" class="alert alert-danger alert-dismissible fade in">
-    <button type="button" class="close" aria-label="Close" ng-click="dismissError()">&times;</button>
+    <button type="button" class="close" aria-label="Close" ng-click="dismissError()">&times;
+    </button>
     {{error}}
   </div>
   <div ng-show="message" class="alert alert-success alert-dismissible fade in">
-    <button type="button" class="close" aria-label="Close" ng-click="dismissSuccess()">&times;</button>
+    <button type="button" class="close" aria-label="Close" ng-click="dismissSuccess()">&times;
+    </button>
     {{message}}
   </div>
 

--- a/python/local_gen.py
+++ b/python/local_gen.py
@@ -75,8 +75,6 @@ def create_scionlab_vm_local_gen(args, tp):
     new_ia = ISD_AS(args.joining_ia)
     core_ia = ISD_AS(args.core_ia)
     local_gen_path = os.path.join(args.package_path, args.user_id, 'gen')
-    # XXX (ercanucan): we remove user's past configs when he re-requests!
-    rmtree(local_gen_path, ignore_errors=True)
     as_obj = generate_certificate(
         new_ia, core_ia, args.core_sign_priv_key_file, args.core_cert_file, args.trc_file)
     write_dispatcher_config(local_gen_path)

--- a/templates/client.conf.tmpl
+++ b/templates/client.conf.tmpl
@@ -1,0 +1,17 @@
+client
+dev tun
+proto udp
+remote {{.ServerIP}} 1194
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+comp-lzo
+verb 3
+mute 10
+<ca>
+{{.CACert}}</ca>
+<cert>
+{{.ClientCert}}</cert>
+<key>
+{{.ClientKey}}</key>

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -1,0 +1,69 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utility
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+// Simple utility function to copy a file.
+func CopyFile(source string, dest string) (err error) {
+	sourcefile, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sourcefile.Close()
+	destfile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer destfile.Close()
+	_, err = io.Copy(destfile, sourcefile)
+	if err == nil {
+		sourceinfo, _ := os.Stat(source)
+		// TODO (jonghoonkwon): do proper error logging!
+		err = os.Chmod(dest, sourceinfo.Mode())
+	}
+	return
+}
+
+// Some helper functions for IP addresses
+func IPToInt(ip string) uint32 {
+	return binary.BigEndian.Uint32(net.ParseIP(ip)[12:])
+}
+
+func IntToIP(ipInt uint32) string {
+	return fmt.Sprintf("%d.%d.%d.%d",
+		byte(ipInt>>24), byte(ipInt>>16), byte(ipInt>>8), byte(ipInt))
+}
+
+func IPIncrement(ip string, diff uint32) string {
+	return IntToIP(IPToInt(ip) + diff)
+}
+
+// returns -1, if ip1 < ip2, 0, if ip1 == ip2, +1, if ip1 > ip2
+func IPCompare(ip1, ip2 string) int8 {
+	if diff := int(IPToInt(ip1)) - int(IPToInt(ip2)); diff > 0 {
+		return 1
+	} else if diff == 0 {
+		return 0
+	} else {
+		return -1
+	}
+}

--- a/utility/utility_test.go
+++ b/utility/utility_test.go
@@ -1,0 +1,77 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utility
+
+import "testing"
+
+type ipComparisonTest struct {
+	ip1  string
+	ip2  string
+	comp int8
+}
+
+type ipConvertTest struct {
+	ipStr string
+	ipInt uint32
+}
+
+type ipIncrementTest struct {
+	ip1 string
+	ip2 string
+	inc uint32
+}
+
+func TestIPFunctions(t *testing.T) {
+	ipComparisonTests := []ipComparisonTest{
+		ipComparisonTest{"0.0.0.0", "0.0.0.1", -1},
+		ipComparisonTest{"0.0.0.0", "0.0.0.0", 0},
+		ipComparisonTest{"0.0.0.1", "0.0.0.0", 1},
+		ipComparisonTest{"0.1.0.0", "0.0.0.0", 1},
+	}
+
+	for _, ipComp := range ipComparisonTests {
+		if IPCompare(ipComp.ip1, ipComp.ip2) != ipComp.comp || IPCompare(ipComp.ip2, ipComp.ip1) !=
+			-ipComp.comp {
+			t.Errorf("IP comparison failed for %v and %v", ipComp.ip1, ipComp.ip2)
+		}
+	}
+
+	ipConvertTests := []ipConvertTest{
+		ipConvertTest{"0.0.0.0", 0},
+		ipConvertTest{"0.0.0.1", 1},
+		ipConvertTest{"0.0.1.0", 256},
+		ipConvertTest{"0.1.0.0", 65536},
+		ipConvertTest{"1.0.0.0", 16777216},
+	}
+
+	for _, ipConv := range ipConvertTests {
+		if IPToInt(ipConv.ipStr) != ipConv.ipInt || IntToIP(ipConv.ipInt) != ipConv.ipStr {
+			t.Errorf("IP conversion failed for %v", ipConv.ipStr)
+		}
+	}
+
+	ipIncrementTests := []ipIncrementTest{
+		ipIncrementTest{"192.168.1.1", "192.168.1.3", 2},
+		ipIncrementTest{"255.255.255.255", "0.0.0.0", 1},
+	}
+
+	for _, ipInc := range ipIncrementTests {
+		if IPIncrement(ipInc.ip1, ipInc.inc) != ipInc.ip2 || IPIncrement(ipInc.ip2, -ipInc.inc) !=
+			ipInc.ip1 {
+			t.Errorf("IP increment failed when incrementing %v by %v", ipInc.ip1, ipInc.inc)
+		}
+	}
+
+}

--- a/vagrant/README
+++ b/vagrant/README
@@ -64,8 +64,8 @@ You can start SCION by executing the following commands:
 'cd /go/src/github.com/netsec-ethz/scion', and
 './scion.sh run'
 
-After your setup is activated at SCIONLab, you should be able to see the beacons being received from SCIONLab AS 1-7.
-You can test this, for example, by using 'tail -f logs/bs1-1014-1.DEBUG'.
+After your setup is activated at the designated SCIONLab AS, you should be able to see the beacons being received.
+You can test this, for example, by using 'tail -f logs/bs1-[[Your AS ID]]-1.DEBUG'.
 
 
 ## Stopping and Restarting the VM

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -15,14 +15,28 @@ Vagrant.configure(2) do |config|
     git clone --recursive -b scionlab git@github.com:ercanucan/scion
     cd scion
     bash -c 'yes | GO_INSTALL=true ./env/deps'
+    cp -r /vagrant/gen .
+  SCRIPT
+  $setup_openvpn = <<-SCRIPT
+    if [ -e /vagrant/client.conf ] # do OpenVPN setup only if config file is present
+    then
+        echo "Setting up OpenVPN."
+        apt-get -y install openvpn
+        cp /vagrant/client.conf /etc/openvpn
+        chmod 600 /etc/openvpn/client.conf
+        systemctl start openvpn@client
+        systemctl enable openvpn@client
+    else
+        echo "No OpenVPN configuration present; keeping standard setup."
+    fi
   SCRIPT
   config.vm.box = "ubuntu/xenial64"
+  # Port forwarding not necessary for OpenVPN setup...
   config.vm.network "forwarded_port", guest: 50000, host: 50000, protocol: "udp"
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
     vb.name = "SCIONLabVM"
   end
   config.vm.provision "shell", privileged: false, inline: $setup_scion
-  config.vm.provision "file", source: "gen", destination: "go/src/github.com/netsec-ethz/scion"
+  config.vm.provision "shell", privileged: true, inline: $setup_openvpn
 end
-

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -129,16 +129,16 @@
 			"revisionTime": "2017-03-22T23:44:13Z"
 		},
 		{
-			"checksumSHA1": "LGalz9Q5YY7z6K08NoQ7emxdYgU=",
+			"checksumSHA1": "dCGjjrVZJoiKUQmaICLhV2PdV40=",
 			"path": "github.com/netsec-ethz/scion/go/lib/addr",
-			"revision": "526daf7a7eeb0f3b1450cea58af7d7cbdd92c5db",
-			"revisionTime": "2017-08-02T12:00:39Z"
+			"revision": "f5066acf929241869b3b614de506d02c27c3b6b1",
+			"revisionTime": "2017-09-27T15:21:54Z"
 		},
 		{
-			"checksumSHA1": "orYxiFhlA/0AkS+Dt9KnR9xxNKs=",
+			"checksumSHA1": "xfkgazGxUH3P9yYobXakYXEgDSA=",
 			"path": "github.com/netsec-ethz/scion/go/lib/common",
-			"revision": "526daf7a7eeb0f3b1450cea58af7d7cbdd92c5db",
-			"revisionTime": "2017-08-02T12:00:39Z"
+			"revision": "f5066acf929241869b3b614de506d02c27c3b6b1",
+			"revisionTime": "2017-09-27T15:21:54Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",


### PR DESCRIPTION
This PR addresses issue  #57 by extending the SCIONLab Coordination Service by an additional connection option via openVPN.
It builds onto PR #69 and extends both the backend and UI with openVPN functionality.
Necessary files such as an openVPN configuration file are added and additional dependencies are documented in the `README.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/72)
<!-- Reviewable:end -->
