### PR TITLE
Pure gen folder

### DIFF
--- a/conf/development.conf.default
+++ b/conf/development.conf.default
@@ -53,6 +53,7 @@ db.max_idle = 3
 
 # SCIONLab AS configs
 server.ia = "1-7"
+server.as_id_base = 1000
 server.ip = "127.0.0.1"
 server.start_port = "50050"
 server.vpn.ip = "10.0.8.1"

--- a/config/config.go
+++ b/config/config.go
@@ -48,10 +48,13 @@ var (
 	DB_MAX_CONNECTIONS, _    = goconf.AppConf.Int("db.max_connections")
 	DB_MAX_IDLE, _           = goconf.AppConf.Int("db.max_idle")
 	SERVER_IA                = goconf.AppConf.String("server.ia")
+	SERVER_AS_ID_BASE        = goconf.AppConf.DefaultInt("server.as_id_base", 1000)
 	SERVER_IP                = goconf.AppConf.String("server.ip")
 	SERVER_START_PORT, _     = goconf.AppConf.Int("server.start_port")
 	SERVER_VPN_IP            = goconf.AppConf.String("server.vpn.ip")
 	SERVER_VPN_START_IP      = goconf.AppConf.String("server.vpn.start_ip")
 	SERVER_VPN_END_IP        = goconf.AppConf.String("server.vpn.end_ip")
 	SERVER_VPN_START_PORT, _ = goconf.AppConf.Int("server.vpn.start_port")
+	VAGRANT_LOCAL_ADDR       = "10.0.2.15"
+	LOCALHOST_ADDR           = "127.0.0.1"
 )

--- a/public/js/services/user.js
+++ b/public/js/services/user.js
@@ -15,7 +15,8 @@ scionApp
         generateSCIONLabVM: function (user) {
             // $http returns a promise, which has a then function, which also returns a promise
             // TODO(ercanucan): compose the URL in a cleaner fashion
-            var url = '/api/as/generateVM?isVPN=' + (!user.isNotVPN) + '&scionLabVMIP=' + user.scionLabVMIP + "&userEmail=" + user.Email;
+            var url = '/api/as/generateVM?isVPN=' + (!user.isNotVPN) + '&isPureGen='
+                + user.isPureGen + '&scionLabVMIP=' + user.scionLabVMIP + "&userEmail=" + user.Email;
             return $http.post(url).then(function (response) {
                 // The then function here is an opportunity to modify the response
                 console.log(response);

--- a/public/partials/user.html
+++ b/public/partials/user.html
@@ -8,9 +8,13 @@
   <p><strong>AccountId:</strong> {{user.AccountID}}</p>
   <p><strong>Secret:</strong> {{user.Secret}}</p>
   <div class="alert alert-info">
-    <p>{{vmInfo.VMText}} <span
-        ng-if="vmInfo.ShowIP">Your registered IP address is <strong>{{vmInfo.VMIP}}</strong>.</span>
-      <span ng-if="vmInfo.ShowVPN">You have chosen a <strong>VPN-based</strong> setup.</span>
+    <p>{{vmInfo.VMText}}
+      <span ng-if="vmInfo.ShowIP">
+        Your registered IP address is <strong>{{vmInfo.VMIP}}</strong>.
+      </span>
+      <span ng-if="vmInfo.ShowVPN">
+        You have chosen a <strong>VPN-based</strong> setup.
+      </span>
     </p>
   </div>
   <div style="color:red">
@@ -21,19 +25,29 @@
     <p>If you have a static public IP address and can receive traffic at port 50000, the border
       router listens on the public IP address. Otherwise, a vpn-based setup is set up for you,
       such that you do not need to apply any further configuration.</p>
+    <p>If you already have a local installation of SCION, you can also choose to only download
+      the gen folder. In that case, no virtual machine will be generated and you can use your
+      local SCION installation.</p>
   </div>
   <br/>
 
   <form name="scionLabVMForm">
     <div class="form-group has-feedback">
-      <label class="btn btn-block btn-primary" ng-disabled="buttonConfig.Update.Disable"
-             data-toggle="tooltip"
-             title="{{buttonConfig.Update.Disable ? buttonConfig.Update.TooltipDisabled :
-             'If you do not have a static public IP address, a vpn-based setup will be ' +
-             'configured for you.'}}">
-        <input type="checkbox" ng-model="user.isNotVPN" name="isNotVPN"
-               ng-disabled="buttonConfig.Update.Disable">
-        My host has a static public IP address and can receive traffic at port 50000.</label>
+      <div class="btn-group-vertical btn-block">
+        <label class="btn btn-primary" ng-disabled="buttonConfig.Update.Disable"
+               data-toggle="tooltip" title="{{buttonConfig.Update.Disable ?
+               buttonConfig.Update.TooltipDisabled : 'If you do not have a static public IP ' +
+               'address, a vpn-based setup will be configured for you.'}}">
+          <input type="checkbox" ng-model="user.isNotVPN" name="isNotVPN"
+                 ng-disabled="buttonConfig.Update.Disable">
+          My host has a static public IP address and can receive traffic at port 50000.
+        </label>
+        <label class="btn btn-default" ng-if="user.isNotVPN" data-toggle="tooltip"
+               title="If in doubt, do not choose this option.">
+          <input type="checkbox" ng-model="user.isPureGen" name="isPureGen">
+          I have a local installation of SCION and only want to download the gen folder.
+        </label>
+      </div>
 
       <input type="text" class="form-control" ng-model="user.scionLabVMIP" name="scionLabVMIP"
              placeholder="My host's public IP address" ng-if="user.isNotVPN"
@@ -42,7 +56,7 @@
     </div>
     <div class="row">
       <div class="col-xs-12">
-        <div id="buttongroup" ng-class="{true:'btn-group-vertical btn-block',
+        <div ng-class="{true:'btn-group-vertical btn-block',
         false:'btn-group btn-group-justified'}[isSmall]">
           <!--<div ng-repeat="button in buttonConfig">-->
           <div ng-repeat="button in buttonConfig" class="btn-group" role="group"

--- a/templates/simple_config_topo.tmpl
+++ b/templates/simple_config_topo.tmpl
@@ -3,7 +3,7 @@
     "bs{{.ISD_ID}}-{{.AS_ID}}-1": {
       "Public": [
         {
-          "Addr": "10.0.2.15",
+          "Addr": "{{.LOCAL_ADDR}}",
           "L4Port": 31041
         }
       ]
@@ -15,7 +15,7 @@
         {
           "Public": [
             {
-              "Addr": "10.0.2.15",
+              "Addr": "{{.LOCAL_ADDR}}",
               "L4Port": 31042
             }
           ]
@@ -38,7 +38,7 @@
             "L4Port": 50000
           },
           "Bind": {
-            "Addr": "10.0.2.15",
+            "Addr": "{{.LOCAL_ADDR}}",
             "L4Port": 50000
           }
         }
@@ -50,7 +50,7 @@
     "cs{{.ISD_ID}}-{{.AS_ID}}-1": {
       "Public": [
         {
-          "Addr": "10.0.2.15",
+          "Addr": "{{.LOCAL_ADDR}}",
           "L4Port": 31043
         }
       ]
@@ -60,7 +60,7 @@
     "ps{{.ISD_ID}}-{{.AS_ID}}-1": {
       "Public": [
         {
-          "Addr": "10.0.2.15",
+          "Addr": "{{.LOCAL_ADDR}}",
           "L4Port": 31044
         }
       ]
@@ -71,7 +71,7 @@
     "sb{{.ISD_ID}}-{{.AS_ID}}-1": {
       "Public": [
         {
-          "Addr": "10.0.2.15",
+          "Addr": "{{.LOCAL_ADDR}}",
           "L4Port": 31045
         }
       ]


### PR DESCRIPTION
This PR builds upon PR #72 and addresses issue #45.
It implements an additional option to only serve the pure gen folder users that are running a local 
installation of SCION.
Both front- and back-end functions are added as well as additional configuration parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/73)
<!-- Reviewable:end -->
