### PR TITLE
Add native HTTPS

### DIFF
--- a/conf/development.conf.default
+++ b/conf/development.conf.default
@@ -24,8 +24,18 @@
 http.bind_address = "127.0.0.1"
 http.bind_port = 8080
 
-# Address visible from outside
+# Use for development setup
 http.host_address = "localhost:8080"
+# Use for production setup via HTTPS
+#http.host_address = "scioncoord.mydomain.xyz"
+
+# Setup for using HTTPS instead of HTTP
+# This requires a registered domain set for "http.host_address" and the ability
+# to listen on ports 80 (HTTP) and 443 (HTTPS).
+# Certificates are automatically generated using Let's encrypt and all HTTP
+# traffic is redirected to HTTPS.
+# This setting overwrites "http.bind_address" and "http.bind_port".
+http.enable_https = 0
 
 # PostMark email service configs
 email.from = "no-reply@scionlab.org"

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ var (
 	HTTP_BIND_PORT, _ = goconf.AppConf.Int("http.bind_port")
 	// address from which the service is reachable from outside
 	HTTP_HOST_ADDRESS        = goconf.AppConf.String("http.host_address")
+	HTTP_ENABLE_HTTPS, _     = goconf.AppConf.Bool("http.enable_https")
 	EMAIL_PM_SERVER_TOKEN    = goconf.AppConf.String("email.pm_server_token")
 	EMAIL_PM_ACCOUNT_TOKEN   = goconf.AppConf.String("email.pm_account_token")
 	EMAIL_FROM               = goconf.AppConf.String("email.from")

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/netsec-ethz/scion-coord/controllers/middleware"
 	"github.com/netsec-ethz/scion-coord/models"
 	"github.com/netsec-ethz/scion-coord/utility"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 // make sure that data about SCIONLab ASes in database is correct
@@ -229,7 +230,22 @@ func main() {
 	static := http.StripPrefix("/public/", http.FileServer(http.Dir("public")))
 	router.PathPrefix("/public/").Handler(xsrfChain.Then(static))
 
-	// listen to HTTP requests
-	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", config.HTTP_BIND_ADDRESS,
-		config.HTTP_BIND_PORT), handlers.CompressHandler(router)))
+	// serve website using https or standard http
+	if config.HTTP_ENABLE_HTTPS {
+		fmt.Printf("Serving website on %v over HTTPS", config.HTTP_HOST_ADDRESS)
+		// redirect HTTP traffic to HTTPS
+		go http.ListenAndServe(":80", http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "https://"+r.Host+r.URL.String(), http.StatusMovedPermanently)
+			}))
+
+		// listen to HTTPS requests
+		log.Fatal(http.Serve(autocert.NewListener(
+			config.HTTP_HOST_ADDRESS), handlers.CompressHandler(router)))
+	} else {
+		fmt.Printf("Serving website on %v over HTTP", config.HTTP_HOST_ADDRESS)
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d",
+			config.HTTP_BIND_ADDRESS, config.HTTP_BIND_PORT), handlers.CompressHandler(router)))
+	}
+
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,6 +171,18 @@
 			"revisionTime": "2017-07-13T16:51:06Z"
 		},
 		{
+			"checksumSHA1": "CSMVjFF7FnylAUUKW1e/4r+VFXA=",
+			"path": "golang.org/x/crypto/acme",
+			"revision": "2509b142fb2b797aa7587dad548f113b2c0f20ce",
+			"revisionTime": "2017-10-23T14:45:55Z"
+		},
+		{
+			"checksumSHA1": "4JU5m5FGcmRYDq/oPlwQC+K8TYA=",
+			"path": "golang.org/x/crypto/acme/autocert",
+			"revision": "2509b142fb2b797aa7587dad548f113b2c0f20ce",
+			"revisionTime": "2017-10-23T14:45:55Z"
+		},
+		{
 			"checksumSHA1": "4D8hxMIaSDEW5pCQk22Xj4DcDh4=",
 			"path": "golang.org/x/crypto/hkdf",
 			"revision": "b176d7def5d71bdd214203491f89843ed217f420",


### PR DESCRIPTION
This PR addresses issue #23 and adds the option to natively serve the website via HTTPS.
If enabled, the certificate is autogenerated via Let's Encrypt.
A registered domain is needed to enable the option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/74)
<!-- Reviewable:end -->
