### PR TITLE
Pre-approved registration and email invitations

### DIFF
--- a/controllers/api/admin.go
+++ b/controllers/api/admin.go
@@ -15,10 +15,15 @@
 package api
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
 
+	"github.com/netsec-ethz/scion-coord/config"
 	"github.com/netsec-ethz/scion-coord/controllers"
+	"github.com/netsec-ethz/scion-coord/controllers/middleware"
+	"github.com/netsec-ethz/scion-coord/email"
+	"github.com/netsec-ethz/scion-coord/models"
 )
 
 type AdminController struct {
@@ -28,6 +33,24 @@ type AdminController struct {
 type adminPageData struct {
 	User user
 }
+
+type invitationInfo struct {
+	FirstName    string
+	LastName     string
+	Email        string
+	Organisation string
+}
+
+type emailTemplateInfo struct {
+	FirstName        string
+	LastName         string
+	InviterFirstName string
+	InviterLastName  string
+	HostAddress      string
+	UUID             string
+}
+
+type invitationsData []invitationInfo
 
 func (c AdminController) AdminInformation(w http.ResponseWriter, r *http.Request) {
 
@@ -44,4 +67,80 @@ func (c AdminController) AdminInformation(w http.ResponseWriter, r *http.Request
 
 	c.JSON(&adminData, w, r)
 	return
+}
+
+func preregisterAndSendInvitation(userSession *models.Session, invitation *invitationInfo) error {
+	// register the user without password
+	account := invitation.Email // use the user's email as a unique account
+	user, err := models.RegisterUser(account, invitation.Organisation,
+		invitation.Email,
+		"", invitation.FirstName, invitation.LastName)
+	if err != nil {
+		return err
+	}
+
+	err = user.UpdateVerified(true)
+	if err != nil {
+		return err
+	}
+
+	data := emailTemplateInfo{
+		FirstName:        invitation.FirstName,
+		LastName:         invitation.LastName,
+		InviterFirstName: userSession.First,
+		InviterLastName:  userSession.Last,
+		HostAddress:      config.HTTP_HOST_ADDRESS,
+		UUID:             user.VerificationUUID,
+	}
+
+	email.ConstructAndSend("invitation.html", "[SCIONLab] Invitation to join the SCION network", data, "scion-invitation", invitation.Email)
+
+	return nil
+}
+
+func (c AdminController) SendInvitationEmails(w http.ResponseWriter, r *http.Request) {
+
+	if err := r.ParseForm(); err != nil {
+		log.Printf("There was an error parsing form for email invitations: %v", err)
+		c.BadRequest(err, w, r)
+		return
+	}
+
+	// parse the JSON coming from the client
+	decoder := json.NewDecoder(r.Body)
+	var invitations invitationsData
+
+	// check if the parsing succeeded
+	if err := decoder.Decode(&invitations); err != nil {
+		log.Printf("Error decoding json data for email invitations: %v", err)
+		c.Error500(err, w, r)
+		return
+	}
+
+	session, userSession, err := middleware.GetUserSession(r)
+	if session == nil || err != nil {
+		log.Printf("No user session found: %v", err)
+		c.Forbidden(err, w, r)
+	}
+
+	errorEmails := []string{}
+	errors := []string{}
+	for _, invitation := range invitations {
+		err := preregisterAndSendInvitation(userSession, &invitation)
+		if err != nil {
+			log.Printf("Error sending invitation email to %v: %v", invitation.Email, err)
+			errorEmails = append(errorEmails, invitation.Email)
+			errors = append(errors, err.Error())
+		} else {
+			errors = append(errors, "")
+		}
+	}
+
+	if len(errors) == 0 {
+		c.Plain("", w, r)
+		return
+	} else {
+		c.JSON(map[string][]string{"messages": errors, "emails": errorEmails}, w, r)
+		return
+	}
 }

--- a/controllers/api/login.go
+++ b/controllers/api/login.go
@@ -120,6 +120,13 @@ func (c *LoginController) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if stored password is invalid due to reset or pre-approved registration
+	if dbUser.PasswordInvalid {
+		log.Printf("Password is not set for user %v.", dbUser.Email)
+		c.Forbidden(err, w, r)
+		return
+	}
+
 	// if the authentication fails
 	if err := dbUser.Authenticate(password); err != nil {
 		log.Printf("Authentication failed for user %v: %v", dbUser.Email, err)

--- a/controllers/api/register.go
+++ b/controllers/api/register.go
@@ -45,32 +45,93 @@ type registrationRequest struct {
 	Captcha              string `json:"captcha"`
 }
 
+type passwordRequest struct {
+	UUID                 string `json:"uuid"`
+	Password             string `json:"password"`
+	PasswordConfirmation string `json:"password_confirmation"`
+}
+
+// check if the password match and that the length is at least 8 chars
+func passwordsAreValid(password, passwordConfirmation string) error {
+	if len(password) < 8 {
+		return fmt.Errorf("%s\n", "Please use at least 8 characters for your password.")
+	}
+
+	if password != passwordConfirmation {
+		return fmt.Errorf("%s\n", "Please enter matching passwords.")
+	}
+
+	return nil
+}
+
 // Method used to validate the registration request
-func (r *registrationRequest) isValid() (bool, error) {
+func (r *registrationRequest) isValid() error {
 
 	//check recaptcha
 	rc := recaptcha.R{Secret: config.CAPTCHA_SECRET_KEY}
 	if !rc.VerifyResponse(r.Captcha) {
-		return false, fmt.Errorf("ReCaptcha error: %s", strings.Join(rc.LastError()[1:], ", "))
+		return fmt.Errorf("ReCaptcha error: %s", strings.Join(rc.LastError()[1:], ", "))
 	}
 
 	// check if any of this is empty
 	if r.Email == "" || r.Password == "" || r.PasswordConfirmation == "" ||
 		r.First == "" || r.Last == "" {
-		return false, fmt.Errorf("%s\n", "You entered incomplete data. First and last name, email and password are mandatory fields.")
+		return fmt.Errorf("%s\n", "You entered incomplete data. First and last name, email and password are mandatory fields.")
 	}
 
 	// check if the password match and that the length is at least 8 chars
-	if len(r.Password) < 8 {
+	return passwordsAreValid(r.Password, r.PasswordConfirmation)
+}
 
-		return false, fmt.Errorf("%s\n", "Please use at least 8 characters for your password.")
+// Method used to set password after pre-approved registration or password reset
+func (c *RegistrationController) SetPassword(w http.ResponseWriter, r *http.Request) {
+
+	// parse the form value
+	if err := r.ParseForm(); err != nil {
+		log.Println(err)
+		c.Error500(fmt.Errorf("Parsing form values failed."), w, r)
+		return
 	}
 
-	if r.Password != r.PasswordConfirmation {
-		return false, fmt.Errorf("%s\n", "Please enter matching passwords.")
+	// parse the JSON coming from the client
+	var passRequest passwordRequest
+	decoder := json.NewDecoder(r.Body)
+
+	// check if the parsing succeeded
+	if err := decoder.Decode(&passRequest); err != nil {
+		log.Println(err)
+		c.Error500(fmt.Errorf("Parsing form values failed."), w, r)
+		return
 	}
 
-	return true, nil
+	if err := passwordsAreValid(passRequest.Password, passRequest.PasswordConfirmation); err != nil {
+		log.Println(err)
+		c.Error500(err, w, r)
+		return
+	}
+
+	//validate link
+	user, err := models.FindUserByVerificationUUID(passRequest.UUID)
+
+	if err != nil {
+		log.Printf("Error setting password. %v is not a valid UUID.", passRequest.UUID)
+		c.BadRequest(fmt.Errorf("Error verifying email address. %v is not a valid user identifier.", passRequest.UUID), w, r)
+		return
+	}
+
+	if !user.PasswordInvalid {
+		c.Error500(fmt.Errorf("Password is already set."), w, r)
+		return
+	}
+
+	if err := user.UpdatePassword(passRequest.Password); err != nil {
+		log.Printf("Error updating the password in the database: %v", err)
+		c.Error500(fmt.Errorf("Error updating the password in the database"), w, r)
+		return
+	}
+
+	c.Plain("", w, r)
+	return
 }
 
 // Method used to validate email address
@@ -133,7 +194,7 @@ func (c *RegistrationController) Register(w http.ResponseWriter, r *http.Request
 	}
 
 	// validate the data
-	if valid, err := regRequest.isValid(); !valid {
+	if err := regRequest.isValid(); err != nil {
 		log.Println(err)
 		c.Error500(err, w, r)
 		return

--- a/email/templates/invitation.html
+++ b/email/templates/invitation.html
@@ -1,0 +1,13 @@
+Dear {{.FirstName}} {{.LastName}}
+
+SCION [1] is a revolutionary new architecture for the internet, which is designed to replace the existing architecture in the future.
+
+{{.InviterFirstName}} {{.InviterLastName}} invites you to join the network and discover its numerous exciting features by signing up for your very own SCIONLab AS.
+
+If you are interested, sign up by using the pre-approved link below [2]; we are very much looking forward to welcoming you in our network.
+
+Best regards
+SCIONLab Coordination Service
+
+[1] https://www.scion-architecture.net
+[2] http://{{.HostAddress}}/#/setPassword/{{.UUID}}

--- a/email/templates/verification.html
+++ b/email/templates/verification.html
@@ -1,4 +1,5 @@
 Hello {{.FirstName}} {{.LastName}}
+
 Thank you for signing up with SCIONLab Coordination Service. To use the service you have to confirm your email address by clicking the link below.
 If you did not expect this email, please ignore it.
 

--- a/main.go
+++ b/main.go
@@ -176,8 +176,14 @@ func main() {
 	router.Handle("/api/verifyEmail/{uuid}", loggingChain.ThenFunc(
 		registrationController.VerifyEmail))
 
+	// set password after pre-approved registration or password reset
+	router.Handle("/api/setPassword", loggingChain.ThenFunc(
+		registrationController.SetPassword)).Methods(http.MethodPost)
+
 	// admin page
 	router.Handle("/api/adminPageData", adminChain.ThenFunc(adminController.AdminInformation))
+	router.Handle("/api/sendInvitations", adminChain.ThenFunc(
+		adminController.SendInvitationEmails)).Methods(http.MethodPost)
 
 	// generates a SCIONLab VM
 	// TODO(ercanucan): fix the authentication

--- a/models/user.go
+++ b/models/user.go
@@ -48,9 +48,11 @@ type Account struct {
 }
 
 type user struct {
-	Id               uint64
-	Email            string `orm:"index"`
-	Password         string
+	Id       uint64
+	Email    string `orm:"index"`
+	Password string
+	// whether the password is invalid due to reset or pre-approved registration
+	PasswordInvalid  bool
 	Salt             string
 	FirstName        string
 	LastName         string
@@ -145,6 +147,9 @@ func RegisterUser(accountName, organisation, email, password, first, last string
 		u.FirstName = first
 		u.LastName = last
 		u.Password = hex.EncodeToString(derivedPassword)
+		if password == "" {
+			u.PasswordInvalid = true
+		}
 		u.Salt = hex.EncodeToString(salt)
 		u.VerificationUUID = uuid.New()
 		//u.TwoFA = false // set it to false
@@ -308,4 +313,22 @@ func (u *user) UpdateVerified(value bool) error {
 	u.Updated = time.Now().UTC()
 	_, err := o.Update(u, "Verified", "Updated")
 	return err
+}
+
+func (u *user) UpdatePassword(password string) (err error) {
+	storedSalt, err := hex.DecodeString(u.Salt)
+	if err != nil {
+		return
+	}
+	derivedPassword, err := derivePassword(password, storedSalt)
+	if err != nil {
+		return
+	}
+
+	u.Password = hex.EncodeToString(derivedPassword)
+	u.PasswordInvalid = password == ""
+	u.Updated = time.Now().UTC()
+
+	_, err = o.Update(u, "Password", "PasswordInvalid", "Updated")
+	return
 }

--- a/public/index.html
+++ b/public/index.html
@@ -18,12 +18,14 @@
   <script src="/public/js/angular-route.js"></script>
   <script src="/public/js/app.js"></script>
   <script src="/public/js/controllers/register.js"></script>
+  <script src="/public/js/controllers/password.js"></script>
   <script src="/public/js/controllers/login.js"></script>
   <script src="/public/js/controllers/user.js"></script>
   <script src="/public/js/controllers/admin.js"></script>
   <script src="/public/js/controllers/header.js"></script>
   <script src="/public/js/controllers/resend.js"></script>
   <script src="/public/js/services/register.js"></script>
+  <script src="/public/js/services/password.js"></script>
   <script src="/public/js/services/login.js"></script>
   <script src="/public/js/services/user.js"></script>
   <script src="/public/js/services/admin.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -13,6 +13,10 @@ const scionApp = angular.module('scionApp', [
                 }]
             }
         })
+        .when('/setPassword/:uuid', {
+            templateUrl: '/public/partials/set_password.html',
+            controller: 'passwordCtrl'
+        })
         .when('/login', {
             templateUrl: '/public/partials/login.html',
             controller: 'loginCtrl'

--- a/public/js/controllers/admin.js
+++ b/public/js/controllers/admin.js
@@ -39,12 +39,51 @@ angular.module('scionApp')
             $scope.error = "";
             $scope.message = "";
 
+            $scope.addChoice = function () {
+                $scope.invitations.push($scope.defaultInvitation());
+            };
+
+            $scope.removeChoice = function () {
+                $scope.invitations.pop();
+            };
+
             $scope.dismissSuccess = function () {
                 $scope.message = "";
             };
 
             $scope.dismissError = function () {
                 $scope.error = "";
+            };
+
+            $scope.sendInvitations = function (invitations) {
+                // TODO (mlegner): Maybe check for duplicates before api call.
+                adminService.sendInvitations(invitations).then(
+                    function (data) {
+                        if (data["emails"].length === 0) {
+                            $scope.error = "";
+                            $scope.message = "All email invitations sent successfully.";
+                            $scope.resetInvitations();
+                        } else {
+                            let emails = data["emails"];
+                            let messages = data["messages"];
+                            err = "There was a problem sending emails to the following addresses: ";
+                            for (let i = 0; i < invitations.length; i++) {
+                                invitations[i].error = messages[i];
+                            }
+                            for (let i = 0; i < emails.length; i++) {
+                                err += emails[i];
+                                if (i < emails.length - 1) {
+                                    err += ", ";
+                                }
+                            }
+                            $scope.error = err;
+                        }
+                    },
+                    function (response) {
+                        $scope.error = "There was an error sending email invitations.";
+                        $scope.message = "";
+                        console.log(response);
+                    });
             };
         }
     ]);

--- a/public/js/controllers/password.js
+++ b/public/js/controllers/password.js
@@ -1,0 +1,26 @@
+scionApp
+    .controller('passwordCtrl', ['$scope', 'passwordService', '$routeParams', '$interval', '$location',
+        function ($scope, passwordService, $routeParams, $interval, $location) {
+
+            $scope.message = "";
+            $scope.error = "";
+
+            $scope.setPassword = function (user) {
+              passwordService.setPassword(user).then(
+                  function (data) {
+                      console.log(data);
+                      $scope.message = "Your password was set successfully. You can now proceed to the login page.";
+                      $scope.user = {uuid: $routeParams.uuid};
+                      $scope.passwordForm.$setPristine(true)
+                  },
+                  function (response) {
+                      console.log(response);
+                      $scope.error = response.data;
+                  }
+              )
+            };
+
+            $scope.user = {uuid: $routeParams.uuid};
+
+        }
+    ]);

--- a/public/js/services/admin.js
+++ b/public/js/services/admin.js
@@ -1,8 +1,15 @@
 angular.module('scionApp')
-    .factory('adminService', ["$http", "$q", function($http, $q) {
+    .factory('adminService', ["$http", "$q", function ($http, $q) {
         return {
             adminPageData: function () {
                 return $http.get('/api/adminPageData').then(function (response) {
+                    console.log(response);
+                    return response.data;
+                });
+            },
+            sendInvitations: function (invitations) {
+                console.log(angular.toJson(invitations));
+                return $http.post('/api/sendInvitations', angular.toJson(invitations)).then(function (response) {
                     console.log(response);
                     return response.data;
                 });

--- a/public/js/services/password.js
+++ b/public/js/services/password.js
@@ -1,0 +1,15 @@
+scionApp
+    .factory('passwordService', ["$http", "$q", function ($http, $q) {
+    return {
+        // set the password for a user
+        setPassword: function (user) {
+            // $http returns a promise, which has a then function, which also returns a promise
+            return $http.post('/api/setPassword', user).then(function (response) {
+                // The then function here is an opportunity to modify the response
+                console.log(response);
+                // The return value gets picked up by the then in the controller.
+                return response.data;
+            });
+        }
+    };
+}]);

--- a/public/partials/admin.html
+++ b/public/partials/admin.html
@@ -1,6 +1,86 @@
 <div class="admin-box" ng-show="user.IsAdmin">
   <br/>
   <br/>
-  <p>Welcome to the SCIONLab admin interface!</p>
+  <p>Welcome to the SCIONLab admin interface! Please contribute to SCIONLab's growth by inviting other people to
+    join via the following form:</p>
+  <br/>
+  <form name="invitationsForm">
+    <!--Use invisible button such that pressing "Enter" submits the form.-->
+    <div class="row">
+      <button
+          style="overflow: visible !important; height: 0 !important; width: 0 !important; margin: 0 !important; border: 0 !important; padding: 0 !important; display: block !important;"
+          type="submit" ng-click="sendInvitations(invitations)"></button>
+    </div>
+    <table width="100%">
+      <tr>
+        <th>First name</th>
+        <th>Last name</th>
+        <th>Email address</th>
+        <th>Organisation</th>
+      </tr>
+      <tr ng-repeat="i in invitations" ng-class="{'has-error' : i.error}">
+        <td>
+          <div class="form-group has-feedback">
+            <input type="text" class="form-control" ng-model="i.FirstName" name="first" placeholder="First name"
+                   required>
+            <span class="glyphicon glyphicon-user form-control-feedback"></span>
+          </div>
+        </td>
+        <td>
+          <div class="form-group has-feedback">
+            <input type="text" class="form-control" ng-model="i.LastName" name="last" placeholder="Last name" required>
+            <span class="glyphicon glyphicon-user form-control-feedback"></span>
+          </div>
+        </td>
+        <td>
+          <ng-form name="emailForm">
+            <div class="form-group has-feedback">
+              <input type="email" class="form-control" ng-model="i.Email" name="email" placeholder="Email address"
+                     required
+                     ng-blur="i.email_entered=true">
+              <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
+              <span class="error"
+                    ng-if="emailForm.email.$error.email && i.email_entered">Please enter a valid email address.</span>
+              <span class="error" ng-if="i.error">{{i.error}}</span>
+            </div>
+          </ng-form>
+        </td>
+        <td>
+          <div class="form-group has-feedback">
+            <input type="text" class="form-control" ng-model="i.Organisation" name="org" placeholder="Organisation">
+            <span class="glyphicon glyphicon-briefcase form-control-feedback"></span>
+          </div>
+        </td>
+      </tr>
+    </table>
 
+    <div class="row">
+      <div class="col-xs-2">
+        <div class="btn-group btn-group-justified">
+          <div class="btn-group" ng-if="invitations.length < 10">
+            <button class="btn btn-success" ng-click="addChoice()" formnovalidate>+</button>
+          </div>
+          <div class="btn-group" ng-if="invitations.length > 1">
+            <button class="btn btn-warning" ng-click="removeChoice()" formnovalidate>-</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <div class="row">
+      <div class="col-xs-12">
+        <button type="submit" class="btn btn-primary btn-block" ng-click="sendInvitations(invitations)">Send invitation emails</button>
+      </div>
+    </div>
+  </form>
+  <div class="spacer"></div>
+  <div ng-show="error" class="alert alert-danger alert-dismissible fade in">
+    <button type="button" class="close" aria-label="Close" ng-click="dismissError()">&times;</button>
+    {{error}}
+  </div>
+  <div ng-show="message" class="alert alert-success alert-dismissible fade in">
+    <button type="button" class="close" aria-label="Close" ng-click="dismissSuccess()">&times;</button>
+    {{message}}
+  </div>
+  <div class="spacer"></div>
 </div>

--- a/public/partials/set_password.html
+++ b/public/partials/set_password.html
@@ -1,0 +1,41 @@
+<div class="register-box">
+  <div class="register-logo">
+    <b>Password</b>
+  </div>
+  <div class="register-box-body">
+    <p class="login-box-msg">Set your SCIONLab Password</p>
+
+
+    <div ng-show="error" ng-model="error" class="alert alert-danger alert-dismissible">
+      {{error}}
+    </div>
+    <div ng-if="message" class="alert alert-success alert-dismissible">
+      {{message}}
+    </div>
+
+
+    <form name="passwordForm" ng-submit="setPassword(user)" ng-hide="message">
+      <div class="form-group has-feedback">
+        <input type="password" class="form-control" ng-model="user.password" name="password" placeholder="Password"
+               ng-required="true" ng-minlength="8" ng-blur="password_entered=true">
+        <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+        <span class="error" ng-if="registration.password.$error.minlength && password_entered">Please use at least 8 characters.</span>
+      </div>
+      <div class="form-group has-feedback">
+        <input type="password" class="form-control" ng-model="user.password_confirmation" check-match="user.password"
+               name="password_confirmation" placeholder="Retype password" ng-required="true"
+               ng-blur="password_confirmation_entered=true">
+        <span class="glyphicon glyphicon-log-in form-control-feedback"></span>
+        <span class="error" ng-if="registration.password_confirmation.$error.match && password_confirmation_entered">Please enter matching passwords.</span>
+      </div>
+      <div class="row">
+        <!-- /.col -->
+        <div class="col-xs-12">
+          <button type="submit" class="btn btn-primary btn-block">Set password</button>
+        </div>
+        <!-- /.col -->
+      </div>
+    </form>
+    <a href="#/login" class="btn btn-block btn-primary" ng-show="message">Login</a>
+  </div>
+</div>


### PR DESCRIPTION
This PR addresses issue #61, building onto PR #79.
It adds front- and backend to enable admins to send email invitations to other people.
Users receiving the invitations are already preapproved and do not need to go
through captcha or enter their personal information.
Implemented admin interface for sending email invitations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/75)
<!-- Reviewable:end -->
