### PR TITLE
Possible nil pointer dereference when loading user information

### DIFF
--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -123,8 +123,8 @@ func (c *LoginController) Me(w http.ResponseWriter, r *http.Request) {
 	_, userSession, err := middleware.GetUserSession(r)
 
 	if err != nil || userSession == nil {
-		log.Println(err)
-		http.Error(w, err.Error(), http.StatusForbidden)
+		log.Printf("Error authenticating user: Not logged in")
+		http.Error(w, "Error authenticating user: Not logged in", http.StatusForbidden)
 		return
 	}
 


### PR DESCRIPTION
This PR fixes a bug which could lead to a nil pointer dereference when loading user information from the front end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/78)
<!-- Reviewable:end -->
