### PR TITLE
Automatically start SCION infrastructure at boot of VM

### DIFF
--- a/vagrant/README
+++ b/vagrant/README
@@ -6,11 +6,11 @@ SCIONLab Virtual Machine
 
 ### For Ubuntu and Mac OS users:
 
-The shell script 'run.sh' will automatically check your system and install
-the necessary packages to run SCIONLabVM, such as 'vagrant' and 'virtualbox'.
+The shell script `run.sh` will automatically check your system and install
+the necessary packages to run SCIONLabVM, such as `vagrant` and `virtualbox`.
 It will also create and configure the SCIONLabVM automatically.
 
-Please Note: SCIONLabVM requires 'vagrant 1.9.7', 'virtualbox 5.0.4' or above.
+Please Note: SCIONLabVM requires `vagrant 1.9.7`, `virtualbox 5.0.4` or above.
 SCIONLabVM also requires that your host machine has a public IP address and
 can receive UDP traffic on port 50000.
 
@@ -19,7 +19,7 @@ apt-get update on your system. Please make sure that all the running VMs are
 suspended or closed before running the script.
 
 If you agree with these requirements, you can then simply setup your SCIONLabVM via:
-'./run.sh' from inside the downloaded folder.
+`./run.sh` from inside the downloaded folder.
 
 Once the setup is finished, you will automatically be inside the SCIONLabVM
 through SSH. After this step, you will be ready to run SCION as described below.
@@ -27,7 +27,7 @@ through SSH. After this step, you will be ready to run SCION as described below.
 
 ### For users of other Linux distributions:
 
-You need to install 'vagrant' and 'virtualbox' manually using your distribution's package manager.
+You need to install `vagrant` and `virtualbox` manually using your distribution`s package manager.
 
 After the install is done, run the following commands from inside the downloaded folder:
     vagrant box add scion/ubuntu-16.04-64-scion
@@ -40,45 +40,43 @@ After this, you are connected to your VM via ssh, where you can run SCION as des
 
 ### For Windows users:
 
-SCIONLabVM requires 'virtualbox' and 'vagrant'.
-First, you need to download and install the 'virtualbox' from:
+SCIONLabVM requires `virtualbox` and `vagrant`.
+First, you need to download and install the `virtualbox` from:
 https://www.virtualbox.org/wiki/Downloads
 
-After this step, you also need to download and install 'vagrant' from:
+After this step, you also need to download and install `vagrant` from:
 https://www.vagrantup.com/downloads.html
 
 Afterwards, open a terminal window and go to the SCIONLabVM folder where the
-'Vagrantfile' is located. Now, you can run `vagrant up`. The command will
-automatically download the base VM image storing 'ubuntu/xenial64', and
-install 'SCION' with all other dependencies.
+`Vagrantfile` is located. Now, you can run `vagrant up`. The command will
+automatically download the base VM image storing `ubuntu/xenial64`, and
+install SCION with all other dependencies.
 
-If the 'vagrant up' command returns the prompt, you are ready to have fun
-with 'SCIONLabVM'.
+If the `vagrant up` command returns the prompt, you are ready to have fun
+with SCIONLabVM.
 
-Finally, you can run 'vagrant ssh' to connect to your VM, where you can run SCION as described below.
+Finally, you can run `vagrant ssh` to connect to your VM, where you can run SCION as described below.
 
 
 ## Running SCION
 
-You can start SCION by executing the following commands:
-'cd /go/src/github.com/netsec-ethz/scion', and
-'./scion.sh run'
+The SCION infrastructure is automatically started when the VM boots up.
 
 After your setup is activated at the designated SCIONLab AS, you should be able to see the beacons being received.
-You can test this, for example, by using 'tail -f logs/bs1-[[Your AS ID]]-1.DEBUG'.
+You can test this by checking the logs in `/go/src/github.com/netsec-ethz/scion/logs/` or by calling `checkbeacons`.
 
 
 ## Stopping and Restarting the VM
 
-You can stop and restart 'SCIONLabVM' using 'vagrant' commands.
-In order to stop the VM, run 'vagrant halt' from the downloaded configuration folder.
-If you want start the VM again, just run 'vagrant up'.
-More information for 'vagrant' commands can be found at:
+You can stop and restart `SCIONLabVM` using `vagrant` commands.
+In order to stop the VM, run `vagrant halt` from the downloaded configuration folder.
+If you want start the VM again, just run `vagrant up`.
+More information for `vagrant` commands can be found at:
 https://www.vagrantup.com/docs/cli
 
 
 ## Current Vagrant Configuration
 
-The configurations for 'vagrant' are defined in the `Vagrantfile` file.
+The configurations for `vagrant` are defined in the `Vagrantfile` file.
 Additional documentation can be found at:
 https://www.vagrantup.com/docs/vagrantfile

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -16,6 +16,8 @@ Vagrant.configure(2) do |config|
     cd scion
     bash -c 'yes | GO_INSTALL=true ./env/deps'
     cp -r /vagrant/gen .
+    echo "alias cdscion='cd /home/ubuntu/go/src/github.com/netsec-ethz/scion'" >> ~/.bash_aliases
+    echo "alias checkbeacons='tail -f /home/ubuntu/go/src/github.com/netsec-ethz/scion/logs/bs*.DEBUG'" >> ~/.bash_aliases
   SCRIPT
   $setup_openvpn = <<-SCRIPT
     if [ -e /vagrant/client.conf ] # do OpenVPN setup only if config file is present
@@ -30,6 +32,11 @@ Vagrant.configure(2) do |config|
         echo "No OpenVPN configuration present; keeping standard setup."
     fi
   SCRIPT
+  $setup_systemd_service = <<-SCRIPT
+    cp /vagrant/scion.service /etc/systemd/system/
+    systemctl enable scion.service
+    systemctl start scion.service
+  SCRIPT
   config.vm.box = "scion/ubuntu-16.04-64-scion"
   # Port forwarding not necessary for OpenVPN setup...
   config.vm.network "forwarded_port", guest: 50000, host: 50000, protocol: "udp"
@@ -39,4 +46,5 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provision "shell", privileged: false, inline: $setup_scion
   config.vm.provision "shell", privileged: true, inline: $setup_openvpn
+  config.vm.provision "shell", privileged: true, inline: $setup_systemd_service
 end

--- a/vagrant/scion.service
+++ b/vagrant/scion.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=SCION infrastructure
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=ubuntu
+WorkingDirectory=/home/ubuntu/go/src/github.com/netsec-ethz/scion/
+Environment="PATH=/home/ubuntu/.local/bin:/home/ubuntu/go/bin:/usr/local/go/bin:/home/ubuntu/bin:/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" "GOPATH=/home/ubuntu/go"
+ExecStart=/home/ubuntu/go/src/github.com/netsec-ethz/scion/scion.sh run
+ExecStop=/home/ubuntu/go/src/github.com/netsec-ethz/scion/scion.sh stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR addresses #87 by adding and automatically enabling a systemd .service file
which starts the SCION infrastructure when the VM boots.
Also some bash aliases are added to simplify access to SCION.
The README file is adjusted accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/96)
<!-- Reviewable:end -->
