### PR TITLE
Debug mode for controlled error message verbosity

### DIFF
--- a/conf/development.conf.default
+++ b/conf/development.conf.default
@@ -16,6 +16,9 @@
 # If uncommented and non-empty it switches logging from console to a file
 #log.file = ""
 
+# If enabled, forwards (possibly sensitive) error messages to the web interface
+log.debug_mode = 0
+
 # If uncommented and non-empty, this directory is used to store generated
 # VM configurations instead of "~/scionLabConfigs"
 #directory.package_directory = ""

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ var (
 	SESSION_ENCRYPTION_KEY   = goconf.AppConf.String("session.encryption_key")
 	SESSION_VERIFICATION_KEY = goconf.AppConf.String("session.verification_key")
 	LOG_FILE                 = goconf.AppConf.String("log.file")
+	LOG_DEBUG_MODE, _        = goconf.AppConf.Bool("log.debug_mode")
 	PACKAGE_DIRECTORY        = goconf.AppConf.DefaultString("directory.package_directory",
 		filepath.Join(os.Getenv("HOME"), "scionLabConfigs"))
 	DB_NAME               = goconf.AppConf.String("db.name")

--- a/controllers/api/as.go
+++ b/controllers/api/as.go
@@ -152,7 +152,7 @@ func (c *ASController) UploadJoinRequest(w http.ResponseWriter, r *http.Request)
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&request); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(w, err, "Error decoding Json")
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	// find the account belonging to the request
@@ -314,7 +314,7 @@ func (c *ASController) PollJoinReply(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error marshaling JSON for account: %v request: %v new AS: %v, %v",
 			account, request.RequestId, joinReply.JoiningIA, err)
-		c.Error500(w, err, "Error marshaling JSON")
+		c.Error500(w, err, "Error during JSON marshaling")
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -557,9 +557,9 @@ func (c *ASController) PollEvents(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		log.Printf("Error during JSON Marshaling. Account: %v, ISD-AS: %v, %v", account, isdas,
+		log.Printf("Error during JSON marshaling. Account: %v, ISD-AS: %v, %v", account, isdas,
 			err)
-		c.Error500(w, err, "Error during JSON Marshaling")
+		c.Error500(w, err, "Error during JSON marshaling")
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -610,9 +610,9 @@ func (c *ASController) ListASes(w http.ResponseWriter, r *http.Request) {
 	resp := c.prepASListResponse(ases)
 	b, err := json.Marshal(resp)
 	if err != nil {
-		log.Printf("Error during JSON Marshaling. Account: %v, ISD-AS: %v, %v", account, req.IsdAs,
+		log.Printf("Error during JSON marshaling. Account: %v, ISD-AS: %v, %v", account, req.IsdAs,
 			err)
-		c.Error500(w, err, "Error during JSON Marshaling")
+		c.Error500(w, err, "Error during JSON marshaling")
 		return
 	}
 	fmt.Fprintln(w, string(b))

--- a/controllers/api/as.go
+++ b/controllers/api/as.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -111,16 +110,16 @@ func (c *ASController) Exists(w http.ResponseWriter, r *http.Request) {
 	isdas := vars["isdas"]
 
 	if isdas == "" {
-		c.BadRequest(errors.New("missing isdas parameter"), w, r)
+		c.BadRequest(w, nil, "Missing isdas parameter")
 		return
 	}
 
 	if _, err := models.FindAsByIsdAs(isdas); err != nil {
-		c.NotFound(errors.New(isdas+" not found"), w, r)
+		c.NotFound(w, nil, isdas+" not found")
 		return
 	}
 
-	fmt.Fprintln(w, "{}")
+	fmt.Fprintln(w, "{}") //TODO: why no status ok?
 }
 
 // Find the account using the 'account_id' in the request
@@ -131,18 +130,18 @@ func (c *ASController) findAndValidateAccount(w http.ResponseWriter, r *http.Req
 	account, err := FindAccountByRequest(r)
 	if err != nil {
 		log.Printf("Error finding account. AccountID: %v, Request: %v: %v", mux.Vars(r)["account_id"], r, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error finding account")
 		return nil, err
 	}
 	owns, err := ValidateAccountOwnsIsdAs(account, isdas)
 	if err != nil {
 		log.Printf("Error validating account %v owns ISD-AS %v: %v", account, isdas, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error validating account %v owns ISD-AS %v", account, isdas)
 		return nil, err
 	}
 	if !owns {
 		log.Printf("Account %v and AS %v do not match.", account, isdas)
-		c.Forbidden(fmt.Errorf("Account %v and AS %v do not match.", account, isdas), w, r)
+		c.Forbidden(w, err, "Account %v and AS %v do not match.", account, isdas)
 		return nil, err
 	}
 	return account, nil
@@ -153,27 +152,27 @@ func (c *ASController) UploadJoinRequest(w http.ResponseWriter, r *http.Request)
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&request); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding Json")
 		return
 	}
 	// find the account belonging to the request
 	account, err := FindAccountByRequest(r)
 	if err != nil {
 		log.Printf("Error finding account for request: %v: %v", request, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error finding account for request")
 		return
 	}
 	isd_to_join := request.IsdToJoin
 	// find core AS in the ISD to join
 	core_ases, err := models.FindCoreASesByIsd(isd_to_join)
 	if err != nil {
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error finding core AS in ISD to join")
 		return
 	}
 	if len(core_ases) == 0 {
 		log.Printf("ISD %v not found or no core ASes exist for this ISD. Account: %v",
 			isd_to_join, account)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "ISD not found or no core ASes exist for this ISD")
 		return
 	}
 	// TODO(ercanucan): Send the request to ALL core ASes in this ISD.
@@ -192,7 +191,7 @@ func (c *ASController) UploadJoinRequest(w http.ResponseWriter, r *http.Request)
 	// insert into the join_requests table in the database
 	if err := join_request.Insert(); err != nil {
 		log.Printf("Error inserting join request for core AS %v: %v", core_as, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error inserting join request")
 		return
 	}
 	log.Printf("Join request successfully received. ISDToJoin: %v Account: %v "+
@@ -205,7 +204,7 @@ func (c *ASController) UploadJoinReply(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reply); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	account, err := models.FindAccountByAccountId(reply.RequesterId)
@@ -228,7 +227,7 @@ func (c *ASController) UploadJoinReply(w http.ResponseWriter, r *http.Request) {
 	if err := joinReply.Insert(); err != nil {
 		log.Printf("Error inserting join reply. Account: %v Request ID: %v ISD-AS: %v, %v",
 			account, joinReply.RequestId, reply.RespondIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error inserting join reply")
 		return
 	}
 	// Change the join req's status to approved/rejected.
@@ -236,14 +235,14 @@ func (c *ASController) UploadJoinReply(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error finding join req. Account: %v Request ID: %v ISD-AS: %v, %v",
 			account, joinReply.RequestId, reply.RespondIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error finding join request")
 		return
 	}
 	join_req.Status = reply.Status
 	if err := join_req.Update(); err != nil {
 		log.Printf("Error updating join req. Account: %v Request ID: %v ISD-AS: %v, %v",
 			account, joinReply.RequestId, reply.RespondIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error updating join request")
 		return
 	}
 	log.Printf("Received a join reply. Account: %v Request ID: %v ISD-AS: %v Status: %v",
@@ -252,7 +251,7 @@ func (c *ASController) UploadJoinReply(w http.ResponseWriter, r *http.Request) {
 		ia, err := addr.IAFromString(joinReply.JoiningIA)
 		if err != nil {
 			log.Printf("Error parsing ISD-AS %v, %v ", joinReply.JoiningIA, err)
-			c.Error500(err, w, r)
+			c.Error500(w, err, "Error parsing ISD-AS")
 			return
 		}
 		new_as := models.As{
@@ -265,7 +264,7 @@ func (c *ASController) UploadJoinReply(w http.ResponseWriter, r *http.Request) {
 		if dbErr := new_as.Insert(); dbErr != nil {
 			log.Printf("Error inserting new AS: %v Account: %v Request ID: %v, %v",
 				new_as.String(), account, reply.RequestId, err)
-			c.Error500(dbErr, w, r)
+			c.Error500(w, dbErr, "Error inserting new AS")
 			return
 		}
 		log.Printf("New AS successfully created. Account: %v Request ID: %v new AS: %v",
@@ -280,13 +279,13 @@ func (c *ASController) PollJoinReply(w http.ResponseWriter, r *http.Request) {
 	}
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&request); err != nil {
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	account, err := FindAccountByRequest(r)
 	if err != nil {
 		log.Printf("Error finding account for request: %v: %v", request.RequestId, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error finding account for request")
 		return
 	}
 	joinReply, err := models.FindJoinReply(account.AccountId, request.RequestId)
@@ -296,9 +295,9 @@ func (c *ASController) PollJoinReply(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "{}")
 		return
 	} else if err != nil {
-		log.Printf("Error during Join Reply lookup. Account: %v Request ID: %v, %v",
+		log.Printf("Error during join reply lookup. Account: %v Request ID: %v, %v",
 			account, request.RequestId, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error during join reply lookup")
 		return
 	}
 	reply := JoinReply{
@@ -315,7 +314,7 @@ func (c *ASController) PollJoinReply(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error marshaling JSON for account: %v request: %v new AS: %v, %v",
 			account, request.RequestId, joinReply.JoiningIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error marshaling JSON")
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -326,7 +325,7 @@ func (c *ASController) UploadConnRequest(w http.ResponseWriter, r *http.Request)
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&cr); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	account, err := c.findAndValidateAccount(w, r, cr.RequestIA)
@@ -360,9 +359,9 @@ func (c *ASController) UploadConnRequest(w http.ResponseWriter, r *http.Request)
 		Status:               models.PENDING,
 	}
 	if err := connRequest.Insert(); err != nil {
-		log.Printf("Error inserting Connection Request. Account %v AS %v: %v", account,
+		log.Printf("Error inserting connection request. Account %v AS %v: %v", account,
 			cr.RequestIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error inserting connection request")
 		// The credits will be granted in foresight and must be removed in case of an error (now)
 		c.rollBackCreditUpdate(w, r, &cr)
 		return
@@ -377,14 +376,14 @@ func (c *ASController) UploadConnReply(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reply); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	as, err := models.FindAsByIsdAs(reply.RequestIA)
 	if err != nil {
 		log.Printf("Error finding the RequestIA. Request ID: %v RequestIA: %v, RespondIA: %v, %v",
 			reply.RequestId, reply.RequestIA, reply.RespondIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error finding the RequestIA")
 		return
 	}
 	account := as.Account
@@ -402,9 +401,9 @@ func (c *ASController) UploadConnReply(w http.ResponseWriter, r *http.Request) {
 		Bandwidth:   reply.Bandwidth,
 	}
 	if err := connReply.Insert(); err != nil {
-		log.Printf("Error inserting Connection Reply. Request ID: %v Account: %v AS: %v: %v",
+		log.Printf("Error inserting connection Reply. request ID: %v Account: %v AS: %v: %v",
 			reply.RequestId, account, reply.RespondIA, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error inserting connection reply")
 		return
 	}
 	// Change the conn req's status to approved/rejected.
@@ -412,14 +411,14 @@ func (c *ASController) UploadConnReply(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error finding conn req. Account: %v Request ID: %v ISD-AS: %v, %v",
 			account, reply.RequestId, reply.RespondIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error finding connection request")
 		return
 	}
 	cr.Status = reply.Status
 	if err := cr.Update(); err != nil {
 		log.Printf("Error updating conn req. Account: %v Request ID: %v ISD-AS: %v, %v",
 			account, reply.RequestId, reply.RespondIA, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error updating connection request")
 		return
 	}
 
@@ -515,7 +514,7 @@ func (c *ASController) PollEvents(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&req); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 
@@ -529,21 +528,21 @@ func (c *ASController) PollEvents(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error while retrieving open join requests. Account: %v, ISD-AS: %v",
 			account, isdas)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error while retrieving open join requests")
 		return
 	}
 	connRequests, err := models.FindOpenConnRequestsByRespondIA(isdas)
 	if err != nil {
 		log.Printf("Error while retrieving connection requests. Account: %v, ISD-AS: %v",
 			account, isdas)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error while retrieving connection Requests")
 		return
 	}
 	connReplies, err := models.FindConnRepliesByRequestIA(isdas)
 	if err != nil {
 		log.Printf("Error while retrieving connection replies. Account: %v, ISD-AS: %v",
 			account, isdas)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error while retrieving connection replies")
 		return
 	}
 
@@ -560,7 +559,7 @@ func (c *ASController) PollEvents(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error during JSON Marshaling. Account: %v, ISD-AS: %v, %v", account, isdas,
 			err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error during JSON Marshaling")
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -587,7 +586,7 @@ func (c *ASController) ListASes(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&req); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	account, err := c.findAndValidateAccount(w, r, req.IsdAs)
@@ -598,14 +597,14 @@ func (c *ASController) ListASes(w http.ResponseWriter, r *http.Request) {
 	ia, err := addr.IAFromString(req.IsdAs)
 	if err != nil {
 		log.Printf("Error parsing ISD-AS %v, %v ", req.IsdAs, err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error parsing ISD-AS")
 		return
 	}
 	ases, err := models.FindASesByIsd(ia.I)
 	if err != nil {
 		log.Printf("Error while retrieving list of ASes. Account: %v, ISD-AS: %v", account,
 			req.IsdAs)
-		c.BadRequest(err, w, r)
+		c.BadRequest(w, err, "Error while retreiving list of ASes")
 		return
 	}
 	resp := c.prepASListResponse(ases)
@@ -613,7 +612,7 @@ func (c *ASController) ListASes(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error during JSON Marshaling. Account: %v, ISD-AS: %v, %v", account, req.IsdAs,
 			err)
-		c.Error500(err, w, r)
+		c.Error500(w, err, "Error during JSON Marshaling")
 		return
 	}
 	fmt.Fprintln(w, string(b))

--- a/controllers/api/login.go
+++ b/controllers/api/login.go
@@ -167,8 +167,8 @@ func (c *LoginController) Login(w http.ResponseWriter, r *http.Request) {
 		c.JSON(&user, w, r)
 
 	} else {
-		log.Println("Auth error")
-		c.Forbidden(w, nil, "Auth error")
+		log.Println("Authentication error")
+		c.Forbidden(w, nil, "Authentication error")
 		return
 	}
 

--- a/controllers/api/login.go
+++ b/controllers/api/login.go
@@ -128,7 +128,8 @@ func (c *LoginController) Login(w http.ResponseWriter, r *http.Request) {
 	// if the authentication fails
 	if err := dbUser.Authenticate(password); err != nil {
 		log.Printf("Authentication failed for user %v: %v", dbUser.Email, err)
-		c.Forbidden(w, err, "Authentication failed for user %v", dbUser.Email)
+		//c.Forbidden(w, err, "Authentication failed for user %v", dbUser.Email)
+		c.Forbidden(w, nil, err.Error())
 		return
 	}
 

--- a/controllers/api/login.go
+++ b/controllers/api/login.go
@@ -128,9 +128,16 @@ func (c *LoginController) Login(w http.ResponseWriter, r *http.Request) {
 	// if the authentication fails
 	if err := dbUser.Authenticate(password); err != nil {
 		log.Printf("Authentication failed for user %v: %v", dbUser.Email, err)
-		//c.Forbidden(w, err, "Authentication failed for user %v", dbUser.Email)
-		c.Forbidden(w, nil, err.Error())
-		return
+		// Distinguish between different authentication errors
+		// The web interface uses this information to react accordingly
+		// 900: Email is not verified, 901: Password invalid
+		if err.Error() == "Email is not verified" {
+			c.Forbidden(w, err, "900 Authentication failed for user %v", dbUser.Email)
+			return
+		} else {
+			c.Forbidden(w, err, "901 Authentication failed for user %v", dbUser.Email)
+			return
+		}
 	}
 
 	// otherwise just continue, because the authentication succeeded

--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -105,26 +105,25 @@ func (s *SCIONLabVMController) GenerateSCIONLabVM(w http.ResponseWriter, r *http
 	isVPN, scionLabVMIP, userEmail, err := s.parseURLParameters(r)
 	if err != nil {
 		log.Printf("Error parsing the parameters: %v", err)
-		s.BadRequest(err, w, r)
+		s.BadRequest(w, err, "Error parsing the parameters")
 		return
 	}
 	// check if there is already a create or update in progress
 	canCreateOrUpdate, err := s.canCreateOrUpdate(userEmail)
 	if err != nil {
 		log.Printf("Error checking pending create or update. User: %v, %v", userEmail, err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error checking pending create or update")
 		return
 	}
 	if !canCreateOrUpdate {
-		s.BadRequest(fmt.Errorf("You have a pending operation. Please wait a few minutes."),
-			w, r)
+		s.BadRequest(w, nil, "You have a pending operation. Please wait a few minutes.")
 		return
 	}
 	// Target SCIONLab ISD and AS to connect to is determined by config file
 	svmInfo, err := s.getSCIONLabVMInfo(scionLabVMIP, userEmail, config.SERVER_IA, isVPN)
 	if err != nil {
 		log.Printf("Error getting SCIONLabVMInfo: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error getting SCIONLabVMInfo")
 		return
 	}
 	// Remove all existing files from UserPackagePath
@@ -133,33 +132,33 @@ func (s *SCIONLabVMController) GenerateSCIONLabVM(w http.ResponseWriter, r *http
 	// Generate topology file
 	if err = s.generateTopologyFile(svmInfo); err != nil {
 		log.Printf("Error generating topology file: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error generating topology file")
 		return
 	}
 	// Generate local gen
 	if err = s.generateLocalGen(svmInfo); err != nil {
 		log.Printf("Error generating local config: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error generating local config")
 		return
 	}
 	// Generate VPN config if this is a VPN setup
 	if svmInfo.IsVPN {
 		if err = s.generateVPNConfig(svmInfo); err != nil {
 			log.Printf("Error generating VPN config: %v", err)
-			s.Error500(err, w, r)
+			s.Error500(w, err, "Error generating VPN config")
 			return
 		}
 	}
 	// Package the VM
 	if err = s.packageSCIONLabVM(svmInfo.UserEmail); err != nil {
 		log.Printf("Error packaging SCIONLabVM: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error packaging SCIONLabVM")
 		return
 	}
 	// Persist the relevant data into the DB
 	if err = s.updateDB(svmInfo); err != nil {
 		log.Printf("Error updating DB tables: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error updating DB tables")
 		return
 	}
 
@@ -494,13 +493,13 @@ func (s *SCIONLabVMController) GetSCIONLabVMASes(w http.ResponseWriter, r *http.
 	log.Printf("Inside GetSCIONLabVMASes = %v", r.URL.Query())
 	scionLabAS := r.URL.Query().Get("scionLabAS")
 	if len(scionLabAS) == 0 {
-		s.BadRequest(fmt.Errorf("scionLabAS parameter missing."), w, r)
+		s.BadRequest(w, nil, "scionLabAS parameter missing")
 		return
 	}
 	vms, err := models.FindSCIONLabVMsByRemoteIA(scionLabAS)
 	if err != nil {
 		log.Printf("Error looking up SCIONLab VMs from DB. SCIONLabAS %v: %v", scionLabAS, err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error looking up SCIONLab VMs from DB")
 		return
 	}
 	vmsCreateResp := []SCIONLabVM{}
@@ -534,7 +533,7 @@ func (s *SCIONLabVMController) GetSCIONLabVMASes(w http.ResponseWriter, r *http.
 	b, err := json.Marshal(resp)
 	if err != nil {
 		log.Printf("Error during JSON Marshaling: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error during JSON Marshaling")
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -558,7 +557,7 @@ func (s *SCIONLabVMController) ConfirmSCIONLabVMASes(w http.ResponseWriter, r *h
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&ASIDs2VMs); err != nil {
 		log.Printf("Error decoding JSON: %v, %v", r.Body, err)
-		s.BadRequest(err, w, r)
+		s.BadRequest(w, err, "Error decoding JSON")
 		return
 	}
 	failedConfirmations := []string{}
@@ -569,8 +568,8 @@ func (s *SCIONLabVMController) ConfirmSCIONLabVMASes(w http.ResponseWriter, r *h
 		}
 	}
 	if len(failedConfirmations) > 0 {
-		s.Error500(fmt.Errorf("Error processing confirmations for the following VMs: %v",
-			failedConfirmations), w, r)
+		s.Error500(w, nil, "Error processing confirmations for the following VMs: %v",
+			failedConfirmations)
 		return
 	}
 	fmt.Fprintln(w, "{}")
@@ -658,13 +657,14 @@ func (s *SCIONLabVMController) ReturnTarball(w http.ResponseWriter, r *http.Requ
 	_, userSession, err := middleware.GetUserSession(r)
 	if err != nil {
 		log.Printf("Error getting the user session: %v", err)
-		s.Forbidden(err, w, r)
+		s.Forbidden(w, err, "Error getting the user session")
 		return
 	}
 	vm, err := models.FindSCIONLabVMByUserEmail(userSession.Email)
 	if err != nil || vm.Status == INACTIVE || vm.Status == REMOVE {
 		log.Printf("No active configuration found for user %v\n", userSession.Email)
-		s.BadRequest(errors.New("No active configuration found"), w, r)
+		s.BadRequest(w, nil, "No active configuration found for user %v",
+			userSession.Email)
 		return
 	}
 
@@ -673,7 +673,7 @@ func (s *SCIONLabVMController) ReturnTarball(w http.ResponseWriter, r *http.Requ
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		log.Printf("Error reading the tarball. FileName: %v, %v", fileName, err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error reading tarball")
 		return
 	}
 	w.Header().Set("Content-Type", "application/gzip")
@@ -688,25 +688,24 @@ func (s *SCIONLabVMController) RemoveSCIONLabVM(w http.ResponseWriter, r *http.R
 	_, userSession, err := middleware.GetUserSession(r)
 	if err != nil {
 		log.Printf("Error getting the user session: %v", err)
-		s.Error500(err, w, r)
+		s.Error500(w, err, "Error getting the user session")
 	}
 	userEmail := userSession.Email
 
 	// check if there is an active VM which can be removed
 	canRemove, svm, err := s.canRemove(userEmail)
 	if err != nil {
-		log.Printf("Error checking if your VM can be removed. User: %v, %v", userEmail, err)
-		s.Error500(err, w, r)
+		log.Printf("Error checking if VM can be removed. User: %v, %v", userEmail, err)
+		s.Error500(w, err, "Error checking if VM can be removed")
 		return
 	}
 	if !canRemove {
-		s.BadRequest(fmt.Errorf("You currently do not have an active SCIONLab VM."), w, r)
+		s.BadRequest(w, nil, "You currently do not have an active SCIONLab VM.")
 		return
 	}
 	svm.Status = REMOVE
 	if err := svm.Update(); err != nil {
-		s.Error500(fmt.Errorf("Error removing entry from SCIONLabVM Table. User: %v, %v",
-			userEmail, err), w, r)
+		s.Error500(w, err, "Error removing entry from SCIONLabVM Table")
 		return
 	}
 	log.Printf("Marked removal of SCIONLabVM of user %v.", userEmail)

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -117,14 +117,12 @@ func populateVMStatusButtons(userEmail string) (vmInfo, uiButtons, error) {
 }
 
 // generates the user-information struct to be used in dynamic HTML pages
-func populateUserData(w http.ResponseWriter, r *http.Request) (u user, err error) {
+func populateUserData(r *http.Request) (u user, err error) {
 	// get the current user session if present.
 	// if not then, abort
 	_, userSession, err := middleware.GetUserSession(r)
 
 	if err != nil || userSession == nil {
-		log.Printf("Error authenticating user: Not logged in")
-		http.Error(w, "Error authenticating user: Not logged in", http.StatusForbidden)
 		return
 	}
 
@@ -151,18 +149,18 @@ func populateUserData(w http.ResponseWriter, r *http.Request) (u user, err error
 // API function that generates all information necessary for displaying the user page
 func (c *LoginController) UserInformation(w http.ResponseWriter, r *http.Request) {
 
-	user, err := populateUserData(w, r)
+	user, err := populateUserData(r)
 	if err != nil {
 		log.Println(err)
-		c.Forbidden(err, w, r)
+		c.Forbidden(w, err, "Error authenticating user: Not logged in")
 		return
 	}
 
 	vmInfo, buttons, err := populateVMStatusButtons(user.Email)
 	if err != nil {
-		c.Forbidden(err, w, r)
 		log.Printf("Error when generating VM info and button configuration for user %v: %v",
 			user.Email, err)
+		c.Forbidden(w, err, "Error when generating VM info and button configuration")
 		return
 	}
 

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -115,31 +115,23 @@ func (c HTTPController) Error(w http.ResponseWriter, err error, errorCode int, d
 	log.Println(fmt.Sprintf(description+": %v", append(a, err)...))
 
 	// Forward the error to the web interface
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	http.Error(w, Verbosity(err, description, a...), errorCode)
 
 }
 
 func (c HTTPController) Error500(w http.ResponseWriter, err error, desc string, a ...interface{}) {
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	http.Error(w, Verbosity(err, desc, a...), http.StatusInternalServerError)
 }
 
 func (c HTTPController) BadRequest(w http.ResponseWriter, err error, desc string, a ...interface{}) {
-
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	http.Error(w, Verbosity(err, desc, a...), http.StatusBadRequest)
 }
 
 func (c HTTPController) NotFound(w http.ResponseWriter, err error, desc string, a ...interface{}) {
-
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	http.Error(w, Verbosity(err, desc, a...), http.StatusNotFound)
 }
 
 func (c HTTPController) Forbidden(w http.ResponseWriter, err error, desc string, a ...interface{}) {
-
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	http.Error(w, Verbosity(err, desc, a...), http.StatusForbidden)
 }
 

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -104,6 +104,17 @@ func (c HTTPController) Plain(data string, w http.ResponseWriter, r *http.Reques
 	}
 }
 
+func (c HTTPController) Error(w http.ResponseWriter, err error, errorCode int, description string, a ...interface{}) {
+
+	// Log the error
+	log.Println(fmt.Sprintf(description+": %v", append(a, err)...))
+
+	// Forward the error to the web interface
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	http.Error(w, Verbosity(err, description, a...), errorCode)
+
+}
+
 func (c HTTPController) Error500(w http.ResponseWriter, err error, desc string, a ...interface{}) {
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	http.Error(w, Verbosity(err, desc, a...), http.StatusInternalServerError)

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -30,6 +30,9 @@ type output interface {
 	JSON(data interface{}, w http.ResponseWriter, r *http.Request)
 	// returns plain text data
 	Plain(data string, w http.ResponseWriter, r *http.Request)
+
+	Error(w http.ResponseWriter, err error, errorCode int, description string, a ...interface{})
+
 	// Response with a 500 and an error
 	Error500(w http.ResponseWriter, err error, desc string, a ...interface{})
 
@@ -104,6 +107,8 @@ func (c HTTPController) Plain(data string, w http.ResponseWriter, r *http.Reques
 	}
 }
 
+//TODO (chaehni): Replace calls to error functions with this generic function.
+//if used throughout, it makes the dedicated error functions obsolete.
 func (c HTTPController) Error(w http.ResponseWriter, err error, errorCode int, description string, a ...interface{}) {
 
 	// Log the error

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func main() {
 
 	// serve website using https or standard http
 	if config.HTTP_ENABLE_HTTPS {
-		fmt.Printf("Serving website on %v over HTTPS", config.HTTP_HOST_ADDRESS)
+		fmt.Printf("Serving website on %v over HTTPS\n", config.HTTP_HOST_ADDRESS)
 		// redirect HTTP traffic to HTTPS
 		go http.ListenAndServe(":80", http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -249,7 +249,7 @@ func main() {
 		log.Fatal(http.Serve(autocert.NewListener(
 			config.HTTP_HOST_ADDRESS), handlers.CompressHandler(router)))
 	} else {
-		fmt.Printf("Serving website on %v over HTTP", config.HTTP_HOST_ADDRESS)
+		fmt.Printf("Serving website on %v over HTTP\n", config.HTTP_HOST_ADDRESS)
 		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d",
 			config.HTTP_BIND_ADDRESS, config.HTTP_BIND_PORT), handlers.CompressHandler(router)))
 	}

--- a/public/js/controllers/login.js
+++ b/public/js/controllers/login.js
@@ -11,7 +11,7 @@ scionApp
                     },
                     function (response) {
                         console.log(response);
-                        if (response.data.trim() === "Email is not verified") {
+                        if (response.data.substring(0,3) === "900") {
                             $rootScope.resendAddress = user.email;
                             $location.path('/resend');
                         } else{


### PR DESCRIPTION
This PR introduces a new mechanism for controlling error output verbosity:

- A control function takes an error and a more generic error description as input and returns an error message based on a "debug mode" flag.
- Functions for error handling are adapted to make use of this in a way, such that new error handling automatically uses this mechanism as well.
- A problem with respect to error handling that lead to nil pointer exceptions in the past is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/120)
<!-- Reviewable:end -->
