### PR TITLE
SCIONLabAS Database

### DIFF
--- a/models/db.go
+++ b/models/db.go
@@ -30,14 +30,18 @@ func init() {
 	orm.RegisterDriver("mysql", orm.DRMySQL)
 	orm.RegisterDataBase("default", "mysql",
 		fmt.Sprintf("%s:%s@(%s:%d)/%s?charset=utf8&parseTime=true",
-			config.DB_USER, config.DB_PASS, config.DB_HOST, config.DB_PORT, config.DB_NAME), config.DB_MAX_CONNECTIONS, config.DB_MAX_IDLE)
+			config.DB_USER, config.DB_PASS, config.DB_HOST, config.DB_PORT, config.DB_NAME),
+		config.DB_MAX_CONNECTIONS, config.DB_MAX_IDLE)
 
 	// prints the queries
 	orm.Debug = false
 
 	// register the models
+	// TODO (@philippmao, mlegner) Remove SCIONLabServer and SCIONLabVM
+	// TODO (@philippmao, mlegner) Remove As models
 	orm.RegisterModel(new(user), new(Account), new(As), new(JoinRequest), new(ConnRequest),
-		new(JoinReply), new(ConnReply), new(SCIONLabServer), new(SCIONLabVM))
+		new(JoinReply), new(ConnReply), new(SCIONLabServer), new(SCIONLabVM),
+		new(SCIONLabAS), new(AttachmentPoint), new(Connection))
 
 	// print verbose logs when generating the tables
 	verbose := true

--- a/models/define.go
+++ b/models/define.go
@@ -1,0 +1,40 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// States in which a scionlabAs or connection can be.
+const (
+	INACTIVE = iota // 0
+	ACTIVE
+	CREATE
+	UPDATE
+	REMOVE
+	REMOVED
+)
+
+// Linktypes
+const (
+	PARENT = iota // 0
+	CHILD
+	CORE
+)
+
+// Types of ScionLabAses
+const (
+	BOX = iota // 0
+	VM
+	DEDICATED
+	SERVER
+)

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -14,67 +14,292 @@
 
 package models
 
-type SCIONLabServer struct {
-	Id                uint64 `orm:"column(id);auto;pk"`
-	IA                string `orm:"unique"` // ISD-AS in which the server is located
-	IP                string // IP address of the machine
-	LastAssignedPort  int    // the last given out port number
-	VPNIP             string // IP address of the machine inside the VPN
-	VPNLastAssignedIP string // the last given out IP address for the VPN
+import (
+	"time"
+
+	"github.com/netsec-ethz/scion/go/lib/addr"
+)
+
+type AttachmentPoint struct {
+	ID          uint64 `orm:"column(id);auto;pk"`
+	VPNIP       string
+	StartVPNIP  string
+	EndVPNIP    string
+	AS          *SCIONLabAS   `orm:"reverse(one)"`
+	Connections []*Connection `orm:"reverse(many);index"` // List of Connections
 }
 
-func (sls *SCIONLabServer) Insert() error {
-	_, err := o.Insert(sls)
+// TODO (@philippmao, mlegner) Add function to get BindIP from Type
+// TODO (@philippmao, mlegner) Link ScionLabAs to user model
+type SCIONLabAS struct {
+	ID          uint64 `orm:"column(id);auto;pk"`
+	UserMail    string // User linked to the AS
+	PublicIP    string // IP address of the SCIONLabAS
+	StartPort   int
+	ISD         int
+	AS          int
+	Core        bool             `orm:"default(false)"` // Is this SCIONLabAS a core AS
+	Status      uint8            `orm:"default(0)"`     // Status of the AS (i.e Active, Create, Update, Remove)
+	Type        uint8            `orm:"default(0)"`     // Type of the AS: (VM, DEDICATED, BOX, SERVER)
+	AP          *AttachmentPoint `orm:"null;rel(one);on_delete(set_null)"`
+	Created     time.Time
+	Updated     time.Time
+	Connections []*Connection `orm:"reverse(many)"` // List of Connections
+}
+
+type Connection struct {
+	ID            uint64           `orm:"column(id);auto;pk"`
+	JoinAS        *SCIONLabAS      `orm:"rel(fk)"` // AS which initiated the connection
+	RespondAP     *AttachmentPoint `orm:"rel(fk)"` // AS which accepted the connection
+	JoinIP        string
+	RespondIP     string
+	JoinBRID      int   // Id of the Initiator Border router, Port = StartPort + Id
+	RespondBRID   int   // Id of the Acceptor Border router
+	Linktype      uint8 // PARENT -> Acceptor is Parent
+	IsVPN         bool
+	JoinStatus    uint8
+	RespondStatus uint8
+	Created       time.Time
+	Updated       time.Time
+}
+
+func (ap *AttachmentPoint) Insert() error {
+	_, err := o.Insert(ap)
 	return err
 }
 
-func (sls *SCIONLabServer) Update() error {
-	_, err := o.Update(sls)
+func (ap *AttachmentPoint) Update() error {
+	_, err := o.Update(ap)
 	return err
 }
 
-func FindSCIONLabServer(ia string) (*SCIONLabServer, error) {
-	s := new(SCIONLabServer)
-	err := o.QueryTable(s).Filter("IA", ia).One(s)
-	return s, err
+func (slas *SCIONLabAS) Insert() error {
+	slas.Created = time.Now().UTC()
+	slas.Updated = time.Now().UTC()
+	_, err := o.Insert(slas)
+	return err
 }
 
-type SCIONLabVM struct {
-	Id           uint64 `orm:"column(id);auto;pk"`
-	UserEmail    string `orm:"unique"`        // Email address of the Owning user
-	IP           string `orm:"unique"`        // IP address of the SCIONLab VM
-	IA           *As    `orm:"rel(fk);index"` // The AS belonging to the VM
-	IsVPN        bool   // is this VM connected via the VPN
-	RemoteIA     string // the SCIONLab AS it connects to
-	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
-	RemoteBR     string // the name of the remote border router for this AS
-	Status       uint8  `orm:"default(0)"` // Status of the VM (i.e Active, Create, Update, Remove)
+func (slas *SCIONLabAS) Update() error {
+	slas.Updated = time.Now().UTC()
+	_, err := o.Update(slas)
+	return err
 }
 
-func FindSCIONLabVMByUserEmail(email string) (*SCIONLabVM, error) {
-	v := new(SCIONLabVM)
-	err := o.QueryTable(v).Filter("UserEmail", email).RelatedSel().One(v)
+func (cn *Connection) Insert() error {
+	cn.Created = time.Now().UTC()
+	cn.Updated = time.Now().UTC()
+	_, err := o.Insert(cn)
+	return err
+}
+
+func (cn *Connection) Update() error {
+	cn.Updated = time.Now().UTC()
+	_, err := o.Update(cn)
+	return err
+}
+
+func (slas *SCIONLabAS) getConnections() ([]*Connection, error) {
+	_, err := o.LoadRelated(slas, "Connections")
+	var v []*Connection
+	if err != nil {
+		return v, err
+	}
+	v = append(v, slas.Connections...)
+	if slas.AP != nil {
+		APCns, err := slas.AP.getConnections()
+		if err != nil {
+			return v, err
+		}
+		v = append(v, APCns...)
+	}
 	return v, err
 }
 
-func FindSCIONLabVMByIPAndRemoteIA(ip, ia string) (*SCIONLabVM, error) {
-	v := new(SCIONLabVM)
-	err := o.QueryTable(v).Filter("IP", ip).Filter("RemoteIA", ia).RelatedSel().One(v)
+func (ap *AttachmentPoint) getConnections() ([]*Connection, error) {
+	_, err := o.LoadRelated(ap, "Connections")
+	return ap.Connections, err
+}
+
+func (cn *Connection) getJoinAS() *SCIONLabAS {
+	v := new(SCIONLabAS)
+	o.QueryTable(v).Filter("ID", cn.JoinAS.ID).RelatedSel().One(v)
+	return v
+}
+
+func (cn *Connection) getRespondAS() *SCIONLabAS {
+	v := new(AttachmentPoint)
+	o.QueryTable(v).Filter("ID", cn.RespondAP.ID).RelatedSel().One(v)
+	o.LoadRelated(v, "AS")
+	return v.AS
+}
+
+type ConnectionInfo struct {
+	CNID        uint64 // Used to find the BorderRouter
+	NeighborISD int
+	NeighborAS  int
+	NeighborIP  string
+	LocalIP     string
+	BindIP      string
+	BRID        int
+	RemotePort  int
+	LocalPort   int
+	Linktype    uint8 //"PARENT","CHILD"
+	IsVPN       bool
+	Status      uint8
+}
+
+// Returns a list of connectionInfo
+// Contains all info needed to populate the topology file
+func (slas *SCIONLabAS) GetConnectionInfo() ([]ConnectionInfo, error) {
+	cns, err := slas.getConnections()
+	if err != nil {
+		return nil, err
+	}
+	var cnInfos []ConnectionInfo
+	var cnInfo ConnectionInfo
+	var bindIP string
+	for _, cn := range cns {
+		// Check if As is initiator or acceptor
+		respondAS := cn.getRespondAS()
+		joinAS := cn.getJoinAS()
+		if joinAS.ID == slas.ID {
+			// If the connection has been removed continue
+			if cn.JoinStatus == REMOVED {
+				continue
+			}
+			// TODO (@philipmao, mlegner) Add function to determine BindIP from type
+			bindIP = cn.JoinIP
+			cnInfo = ConnectionInfo{
+				CNID:        cn.ID,
+				NeighborISD: respondAS.ISD,
+				NeighborAS:  respondAS.AS,
+				NeighborIP:  cn.RespondIP,
+				LocalIP:     cn.JoinIP,
+				BindIP:      bindIP,
+				BRID:        cn.JoinBRID,
+				RemotePort:  respondAS.StartPort + cn.RespondBRID - 1,
+				LocalPort:   joinAS.StartPort + cn.JoinBRID - 1,
+				Linktype:    cn.Linktype,
+				IsVPN:       cn.IsVPN,
+				Status:      cn.JoinStatus,
+			}
+		} else {
+			var linktype = cn.Linktype
+			if cn.Linktype == PARENT {
+				linktype = CHILD
+			}
+			if cn.RespondStatus == REMOVED {
+				continue
+			}
+			// TODO (@philipmao, mlegner) Add function to determine BindIP from type
+			bindIP = cn.RespondIP
+			cnInfo = ConnectionInfo{
+				CNID:        cn.ID,
+				NeighborISD: joinAS.ISD,
+				NeighborAS:  joinAS.AS,
+				NeighborIP:  cn.JoinIP,
+				LocalIP:     cn.RespondIP,
+				BindIP:      bindIP,
+				BRID:        cn.RespondBRID,
+				RemotePort:  joinAS.StartPort + cn.JoinBRID - 1,
+				LocalPort:   respondAS.StartPort + cn.RespondBRID - 1,
+				Linktype:    linktype,
+				IsVPN:       cn.IsVPN,
+				Status:      cn.RespondStatus,
+			}
+		}
+		cnInfos = append(cnInfos, cnInfo)
+	}
+	return cnInfos, err
+}
+
+// Update the Status of a Connection using a ConnectionInfo Object
+func (slas *SCIONLabAS) UpdateDBConnection(cnInfo ConnectionInfo) error {
+	cn := new(Connection)
+	err := o.QueryTable(cn).Filter("ID", cnInfo.CNID).RelatedSel().One(cn)
+	if err != nil {
+		return err
+	}
+	respondAS := cn.getRespondAS()
+	joinAS := cn.getJoinAS()
+	if joinAS.ID == slas.ID {
+		if !cn.IsVPN {
+			cn.JoinIP = slas.PublicIP
+		}
+		cn.JoinStatus = cnInfo.Status
+		// If the Connection updated or going to be removed both parties need this status
+		if cnInfo.Status == REMOVE || cnInfo.Status == UPDATE {
+			cn.RespondStatus = cnInfo.Status
+		}
+		cn.JoinBRID = cnInfo.BRID
+	}
+	if respondAS.ID == slas.ID {
+		if !cn.IsVPN {
+			cn.RespondIP = slas.PublicIP
+		}
+		cn.RespondStatus = cnInfo.Status
+		if cnInfo.Status == REMOVE || cnInfo.Status == UPDATE {
+			cn.JoinStatus = cnInfo.Status
+		}
+		cn.RespondBRID = cnInfo.BRID
+	}
+	if err := cn.Update(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Returns all Attachment Point ASes
+func GetAllAPs() ([]*SCIONLabAS, error) {
+	var v []AttachmentPoint
+	var w []*SCIONLabAS
+	_, err := o.QueryTable(new(AttachmentPoint)).RelatedSel().All(&v)
+	if err != nil {
+		return w, err
+	}
+	for _, ap := range v {
+		o.LoadRelated(&ap, "AS")
+		w = append(w, ap.AS)
+	}
+	return w, err
+}
+
+// Find SCIONLabAses by UserEmail
+func FindSCIONLabASesByUserEmail(email string) ([]SCIONLabAS, error) {
+	var v []SCIONLabAS
+	_, err := o.QueryTable(new(SCIONLabAS)).Filter("UserMail", email).RelatedSel().All(&v)
 	return v, err
 }
 
-func FindSCIONLabVMsByRemoteIA(remoteIA string) ([]SCIONLabVM, error) {
-	var v []SCIONLabVM
-	_, err := o.QueryTable(new(SCIONLabVM)).Filter("RemoteIA", remoteIA).RelatedSel().All(&v)
+// Find SCIONLabASes by UserEmail and Type
+func FindSCIONLabASesByUEmailAndType(email string, Type uint8) ([]SCIONLabAS, error) {
+	var v []SCIONLabAS
+	_, err := o.QueryTable(new(SCIONLabAS)).Filter("UserMail", email).Filter("Type", Type).RelatedSel().All(&v)
 	return v, err
 }
 
-func (svm *SCIONLabVM) Insert() error {
-	_, err := o.Insert(svm)
-	return err
+// Find SCIONLabAS by the IA string
+func FindSCIONLabASByIAString(ia string) (*SCIONLabAS, error) {
+	v := new(SCIONLabAS)
+	IA, err1 := addr.IAFromString(ia)
+	if err1 != nil {
+		return nil, err1
+	}
+	err := o.QueryTable(v).Filter("ISD", IA.I).Filter("AS", IA.A).RelatedSel().One(v)
+	return v, err
 }
 
-func (svm *SCIONLabVM) Update() error {
-	_, err := o.Update(svm)
-	return err
+// Find SCIONLabAS by the ISD AS int
+func FindSCIONLabASByIAInt(isd int, as int) (*SCIONLabAS, error) {
+	v := new(SCIONLabAS)
+	err := o.QueryTable(v).Filter("ISD", isd).Filter("AS", as).RelatedSel().One(v)
+	return v, err
+}
+
+// Find SCIONLabAS by the Public IP
+func FindSCIONLabASesByIP(ip string) ([]SCIONLabAS, error) {
+	var v []SCIONLabAS
+	_, err := o.QueryTable(new(SCIONLabAS)).Filter("PublicIP", ip).RelatedSel().All(&v)
+	return v, err
 }

--- a/models/scion_lab_test.go
+++ b/models/scion_lab_test.go
@@ -1,0 +1,272 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	// Insert Users
+	u1, err := RegisterUser("ac1", "ETH", "mail1", "pw", "a", "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u2, err := RegisterUser("ac2", "ETH", "mail2", "pw2", "c", "d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u3, err := RegisterUser("ac3", "ETH", "mail3", "pw3", "f", "g")
+	if err != nil {
+		t.Fatal(err)
+	}
+	slas1 := &SCIONLabAS{
+		UserMail:  u1.Email,
+		PublicIP:  "1.2.3.4",
+		StartPort: 50000,
+		ISD:       1,
+		AS:        1,
+		Status:    ACTIVE,
+		Type:      BOX,
+	}
+	slas2 := &SCIONLabAS{
+		UserMail:  u2.Email,
+		StartPort: 50000,
+		ISD:       1,
+		AS:        2,
+		Status:    INACTIVE,
+		Type:      VM,
+	}
+	slas3 := &SCIONLabAS{
+		UserMail:  u3.Email,
+		PublicIP:  "6.4.9.4",
+		StartPort: 50000,
+		ISD:       2,
+		AS:        5,
+		Status:    UPDATE,
+		Type:      DEDICATED,
+		Core:      true,
+	}
+	err = slas1.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = slas2.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = slas3.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// SLAS1 & 3 are attachment Points
+	ap1 := &AttachmentPoint{
+		VPNIP:      "10.0.0.1",
+		StartVPNIP: "10.0.0.2",
+		EndVPNIP:   "10.0.0.19",
+	}
+	ap2 := &AttachmentPoint{
+		VPNIP:      "62.0.0.1",
+		StartVPNIP: "62.0.0.2",
+		EndVPNIP:   "62.0.0.254",
+	}
+	err = ap1.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ap2.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Link AP to SLAS
+	slas1.AP = ap1
+	err = slas1.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slas3.AP = ap2
+	err = slas3.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Insert Connections
+	cn1 := Connection{
+		JoinIP:        "10.0.0.3",
+		RespondIP:     slas1.AP.VPNIP,
+		JoinAS:        slas2,
+		RespondAP:     ap1,
+		JoinBRID:      2,
+		RespondBRID:   6,
+		Linktype:      PARENT,
+		IsVPN:         true,
+		JoinStatus:    CREATE,
+		RespondStatus: ACTIVE,
+	}
+	cn2 := Connection{
+		JoinIP:        slas1.PublicIP,
+		RespondIP:     slas3.PublicIP,
+		JoinAS:        slas1,
+		RespondAP:     ap2,
+		JoinBRID:      2,
+		RespondBRID:   1,
+		Linktype:      PARENT,
+		IsVPN:         false,
+		JoinStatus:    REMOVE,
+		RespondStatus: REMOVED,
+	}
+	cn3 := Connection{
+		JoinIP:        "62.0.0.53",
+		RespondIP:     slas3.AP.VPNIP,
+		JoinAS:        slas2,
+		RespondAP:     ap2,
+		JoinBRID:      4,
+		RespondBRID:   7,
+		Linktype:      PARENT,
+		IsVPN:         true,
+		JoinStatus:    ACTIVE,
+		RespondStatus: CREATE,
+	}
+	err = cn1.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cn2.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cn3.Insert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Test FindSCIONLabASByIA
+	s1, err := FindSCIONLabASByIAString("1-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("FindSCIONLabASByIA 1-1: %v", s1)
+	t.Logf("FindSCIONLabASByIA AP 1-1: %v", s1.AP)
+	s3, err := FindSCIONLabASByIAString("2-5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("FindSCIONLabASByIA 2-5: %v", s3)
+	t.Logf("FindSCIONLabASByIA AP 2-5: %v", s3.AP)
+	// Test FindSCIONLabASByTypeUserEmail
+	list, err := FindSCIONLabASesByUEmailAndType("mail2", VM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var s2 SCIONLabAS
+	for _, as := range list {
+		t.Logf("FindSCIONLabASByUmailAndType mail2, VM: %v", as)
+		s2 = as
+	}
+	// Test FindSCIONLabASesByUserEmail
+	smail1, err := FindSCIONLabASesByUserEmail("mail1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, slas := range smail1 {
+		t.Logf("FindSCIONLabAsesByUserEmail mail1: %v", slas)
+	}
+	// Test FindSCIONLabAsesByIP
+	sIP, err := FindSCIONLabASesByIP("1.2.3.4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sIP1 := range sIP {
+		t.Logf("FindSCIONLabAsesByIP 1.2.3.4: %v", sIP1)
+	}
+	// Test GetAllAPS
+	APList, err := GetAllAPs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ap := range APList {
+		t.Logf("GetAllAPs: %v", ap)
+	}
+	// Test FindSCIONLabASByIAInt
+	as, err := FindSCIONLabASByIAInt(1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("FindSCIONLabASByIAInt 1-2: %v", as)
+	// Test GetConnectionInfo for all Ases
+	cns1, err := s1.GetConnectionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cn := range cns1 {
+		t.Log("Connection s1: %v", cn)
+	}
+	cns2, err := s2.GetConnectionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cn := range cns2 {
+		t.Log("Connection s2: %v", cn)
+	}
+	cns3, err := s3.GetConnectionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cn := range cns3 {
+		t.Log("Connection s3: %v", cn)
+	}
+	// Test UpdateDBConnection
+	s1.PublicIP = "CONNECTIONTEST"
+	cns1[0].BRID = 99999
+	cns1[0].Status = UPDATE
+	err = s1.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s1.UpdateDBConnection(cns1[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2.PublicIP = "CONNECTIONTEST"
+	cns2[0].BRID = 99999
+	cns2[0].Status = UPDATE
+	err = s2.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s2.UpdateDBConnection(cns2[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	cns1, err = s1.GetConnectionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cn := range cns1 {
+		t.Log("Connection s1: %v", cn)
+	}
+	cns2, err = s2.GetConnectionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cn := range cns2 {
+		t.Log("Connection s2: %v", cn)
+	}
+	cns3, err = s3.GetConnectionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cn := range cns3 {
+		t.Log("Connection s3: %v", cn)
+	}
+}

--- a/models/scion_lab_vm.go
+++ b/models/scion_lab_vm.go
@@ -1,0 +1,82 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// TODO (@philippmao, mlegner) Remove this file once the SCIONLabVMController is updated
+
+type SCIONLabServer struct {
+	Id                uint64 `orm:"column(id);auto;pk"`
+	IA                string `orm:"unique"` // ISD-AS in which the server is located
+	IP                string // IP address of the machine
+	LastAssignedPort  int    // the last given out port number
+	VPNIP             string // IP address of the machine inside the VPN
+	VPNLastAssignedIP string // the last given out IP address for the VPN
+}
+
+func (sls *SCIONLabServer) Insert() error {
+	_, err := o.Insert(sls)
+	return err
+}
+
+func (sls *SCIONLabServer) Update() error {
+	_, err := o.Update(sls)
+	return err
+}
+
+func FindSCIONLabServer(ia string) (*SCIONLabServer, error) {
+	s := new(SCIONLabServer)
+	err := o.QueryTable(s).Filter("IA", ia).One(s)
+	return s, err
+}
+
+type SCIONLabVM struct {
+	Id           uint64 `orm:"column(id);auto;pk"`
+	UserEmail    string `orm:"unique"`        // Email address of the Owning user
+	IP           string `orm:"unique"`        // IP address of the SCIONLab VM
+	IA           *As    `orm:"rel(fk);index"` // The AS belonging to the VM
+	IsVPN        bool   // is this VM connected via the VPN
+	RemoteIA     string // the SCIONLab AS it connects to
+	RemoteIAPort int    // port number of the remote SCIONLab AS being connected to
+	RemoteBR     string // the name of the remote border router for this AS
+	Status       uint8  `orm:"default(0)"` // Status of the VM (i.e Active, Create, Update, Remove)
+}
+
+func FindSCIONLabVMByUserEmail(email string) (*SCIONLabVM, error) {
+	v := new(SCIONLabVM)
+	err := o.QueryTable(v).Filter("UserEmail", email).RelatedSel().One(v)
+	return v, err
+}
+
+func FindSCIONLabVMByIPAndRemoteIA(ip, ia string) (*SCIONLabVM, error) {
+	v := new(SCIONLabVM)
+	err := o.QueryTable(v).Filter("IP", ip).Filter("RemoteIA", ia).RelatedSel().One(v)
+	return v, err
+}
+
+func FindSCIONLabVMsByRemoteIA(remoteIA string) ([]SCIONLabVM, error) {
+	var v []SCIONLabVM
+	_, err := o.QueryTable(new(SCIONLabVM)).Filter("RemoteIA", remoteIA).RelatedSel().All(&v)
+	return v, err
+}
+
+func (svm *SCIONLabVM) Insert() error {
+	_, err := o.Insert(svm)
+	return err
+}
+
+func (svm *SCIONLabVM) Update() error {
+	_, err := o.Update(svm)
+	return err
+}


### PR DESCRIPTION
This PR adds the SCIONLabAS Database to the coordinator:

- SCIONLabAS/AttachmentPoint/Connection models in models/scion_lab.go
- Assortment of Utility Functions for the new models in models/scion_lab.go
- New models are added to the database in models/db.go
- Moved previous contents of models/scion_lab.go to models/scion_lab_vm.go
- Added a test function in models/scion_lab_test.go

Once the SCIONLabVMController is updated to accommodate the new Database models/scoin_lab_vm.go can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/121)
<!-- Reviewable:end -->
