### PR TITLE
Solve VM clock issues

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -16,6 +16,8 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 50000, host: 50000, protocol: "udp"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|
+    vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-interval", 10000 ]
+    vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
     vb.memory = "2048"
     vb.name = "SCIONLabVM"
   end


### PR DESCRIPTION
Prevent SCIONLab VMs from experiencing clock drift issues after being suspended or paused.
Use host hardware clock to periodically sync guest clock and lower drift threshold were time gets set instead of smoothly adjusted.

VirtualBox behavior is documented here: https://www.virtualbox.org/manual/ch09.html#changetimesync

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/138)
<!-- Reviewable:end -->
