### PR TITLE
Bugfix: wrongly updated joinBRID

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -425,6 +425,7 @@ func (s *SCIONLabASController) updateDB(asInfo *SCIONLabASInfo) error {
 				userEmail, err)
 
 		}
+		cn.BRID = 1
 		cn.IsVPN = asInfo.IsVPN
 		cn.NeighborStatus = asInfo.LocalAS.Status
 		cn.Status = models.ACTIVE

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -413,6 +413,7 @@ func (as *SCIONLabAS) UpdateDBConnection(cnInfo *ConnectionInfo) error {
 		}
 		cn.JoinStatus = cnInfo.Status
 		cn.RespondStatus = cnInfo.NeighborStatus
+		cn.JoinBRID = cnInfo.BRID
 	}
 	if respondAS.ID == as.ID {
 		if !cn.IsVPN {

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -413,7 +413,6 @@ func (as *SCIONLabAS) UpdateDBConnection(cnInfo *ConnectionInfo) error {
 		}
 		cn.JoinStatus = cnInfo.Status
 		cn.RespondStatus = cnInfo.NeighborStatus
-		cn.JoinBRID = cnInfo.BRID
 	}
 	if respondAS.ID == as.ID {
 		if !cn.IsVPN {


### PR DESCRIPTION
`joinBRID` in `scion_coord_test.connection` table is wrongly updated with `respondBRID`, in case the user's ScionLabAS is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/154)
<!-- Reviewable:end -->
