### PR TITLE
Use readable names for database tables and fix AS/AP relationship

### DIFF
--- a/models/db.go
+++ b/models/db.go
@@ -26,6 +26,18 @@ var (
 	o orm.Ormer
 )
 
+func (u *SCIONLabAS) TableName() string {
+	return "scion_lab_as"
+}
+
+func (u *SCIONBox) TableName() string {
+	return "scion_box"
+}
+
+func (u *ISDLocation) TableName() string {
+	return "isd_location"
+}
+
 func init() {
 	orm.RegisterDriver("mysql", orm.DRMySQL)
 	orm.RegisterDataBase("default", "mysql",

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -439,15 +439,25 @@ func (as *SCIONLabAS) UpdateASAndConnection(cnInfo *ConnectionInfo) error {
 
 // Returns all Attachment Point ASes
 func GetAllAPs() ([]*SCIONLabAS, error) {
+	var aps []*AttachmentPoint
 	var ases []*SCIONLabAS
-	_, err := o.QueryTable(new(SCIONLabAS)).Exclude("AP", nil).RelatedSel().All(&ases)
+	_, err := o.QueryTable(new(AttachmentPoint)).RelatedSel().All(&aps)
+	for _, ap := range aps {
+		ases = append(ases, ap.AS)
+	}
 	return ases, err
 }
 
 // Returns all Attachment Point ASes in the given ISD
 func FindAllAPsByISD(isd int) ([]*SCIONLabAS, error) {
+	var aps []*AttachmentPoint
 	var ases []*SCIONLabAS
-	_, err := o.QueryTable(new(SCIONLabAS)).Filter("ISD", isd).Exclude("AP", nil).RelatedSel().All(&ases)
+	_, err := o.QueryTable(new(AttachmentPoint)).RelatedSel().All(&aps)
+	for _, ap := range aps {
+		if ap.AS.ISD == isd {
+			ases = append(ases, ap.AS)
+		}
+	}
 	return ases, err
 }
 

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -34,7 +34,7 @@ type AttachmentPoint struct {
 	VPNIP       string
 	StartVPNIP  string
 	EndVPNIP    string
-	AS          *SCIONLabAS   `orm:"reverse(one)"`
+	AS          *SCIONLabAS   `orm:"column(as_id);rel(one);on_delete(cascade)"`
 	Connections []*Connection `orm:"reverse(many);index"` // List of Connections
 }
 
@@ -51,7 +51,7 @@ type SCIONLabAS struct {
 	Label       string           // Optional label for this AS (can be chosen by the user)
 	Status      uint8            `orm:"default(0)"` // Status of the AS: ACTIVE, CREATE, ...
 	Type        uint8            `orm:"default(0)"` // Type of the AS: BOX, VM, DEDICATED, ...
-	AP          *AttachmentPoint `orm:"null;rel(one);on_delete(set_null)"`
+	AP          *AttachmentPoint `orm:"null;reverse(one)"`
 	Credits     int64
 	Created     time.Time
 	Updated     time.Time

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -491,6 +491,7 @@ func FindSCIONLabASByIAString(ia string) (*SCIONLabAS, error) {
 		return nil, err1
 	}
 	err := o.QueryTable(as).Filter("ISD", IA.I).Filter("ASID", IA.A).RelatedSel().One(as)
+	o.LoadRelated(as, "AP")
 	return as, err
 }
 

--- a/models/scion_lab_test.go
+++ b/models/scion_lab_test.go
@@ -57,11 +57,13 @@ var (
 		VPNIP:      "10.0.0.1",
 		StartVPNIP: "10.0.0.2",
 		EndVPNIP:   "10.0.0.19",
+		AS:         as1,
 	}
 	ap2 = &AttachmentPoint{
 		VPNIP:      "62.0.0.1",
 		StartVPNIP: "62.0.0.2",
 		EndVPNIP:   "62.0.255.254",
+		AS:         as2,
 	}
 
 	// Connections
@@ -140,17 +142,6 @@ func TestSCIONLabAS(t *testing.T) {
 			t.Fatal(err)
 		}
 		err = ap2.Insert()
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Link AP to AS
-		as1.AP = ap1
-		err = as1.Update()
-		if err != nil {
-			t.Fatal(err)
-		}
-		as3.AP = ap2
-		err = as3.Update()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,14 +230,14 @@ func TestSCIONLabAS(t *testing.T) {
 		for _, cn := range cns1 {
 			t.Log("Connection s1: %v", cn)
 		}
-		cns2, err := s1.GetConnectionInfo()
+		cns2, err := s2.GetConnectionInfo()
 		if err != nil {
 			t.Fatal(err)
 		}
 		for _, cn := range cns2 {
 			t.Log("Connection s2: %v", cn)
 		}
-		cns3, err := s1.GetConnectionInfo()
+		cns3, err := s3.GetConnectionInfo()
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
If we have to migrate the database anyway, we can also start using readable names for the MySQL tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/156)
<!-- Reviewable:end -->
