### PR TITLE
Disable configuration form and buttons for infrastructure ASes

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -276,6 +276,9 @@ func (s *SCIONLabASController) canConfigure(userEmail string, asID int) error {
 		return err
 	}
 	if (as.Status == models.ACTIVE) || (as.Status == models.INACTIVE) {
+		if as.Type == models.INFRASTRUCTURE {
+			return errors.New("Cannot modify infrastructure ASes")
+		}
 		return nil
 	}
 	return errors.New("The given AS has a pending update request")
@@ -672,6 +675,9 @@ func (s *SCIONLabASController) canRemove(userEmail, asID string) (bool, *models.
 		}
 	}
 	if as.Status == models.ACTIVE {
+		if as.Type == models.INFRASTRUCTURE {
+			return false, nil, nil, errors.New("Cannot remove infrastructure ASes")
+		}
 		cns, err := as.GetJoinConnectionInfo()
 		if err != nil {
 			return false, nil, nil, fmt.Errorf("Error looking up connections: %v", err)

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -140,6 +140,11 @@ func populateASStatusButtons(userEmail string) ([]asInfo, []string, error) {
 			asI.ASText = "Your SCIONLab AS configuration is currently scheduled for removal."
 			buttons.Download.Disable = true
 		}
+		if asI.Type == models.INFRASTRUCTURE {
+			buttons.Configure.Hide = true
+			buttons.Download.Hide = true
+			buttons.Disconnect.Hide = true
+		}
 		asI.Buttons = buttons
 
 		asInfos = append(asInfos, asI)

--- a/public/partials/user.html
+++ b/public/partials/user.html
@@ -68,42 +68,47 @@
     <div class="form-group has-feedback">
       <label>Attachment point to connect to</label>
         <select class="form-control dropdown-toggle" ng-model="asInfo.AP"
-                ng-options="x for x in aps">
+                ng-options="x for x in aps" ng-disabled="asInfo.Type == 0">
         </select>
       <span class="glyphicon glyphicon-cloud form-control-feedback"></span>
     </div>
     <div class="form-group has-feedback">
       <label>Label for this AS (optional)</label>
       <input type="text" class="form-control" ng-model="asInfo.Label" name="Label"
-             placeholder="Label for this AS">
+             placeholder="Label for this AS" ng-disabled="asInfo.Type == 0">
       <span class="glyphicon glyphicon-pencil form-control-feedback"></span>
     </div>
     <div class="form-group">
       <div class="radio">
-        <label><input type="radio" ng-model="asInfo.Type" value="1" >
+        <label><input type="radio" ng-model="asInfo.Type" value="1" ng-disabled="asInfo.Type == 0">
           Install inside a virtual machine
         </label>
       </div>
       <div class="radio">
-        <label><input type="radio" ng-model="asInfo.Type" value="2" >
+        <label><input type="radio" ng-model="asInfo.Type" value="2" ng-disabled="asInfo.Type == 0">
           Install on a dedicated SCION system
         </label>
       </div>
     </div>
     <div class="form-group checkbox">
-        <label><input type="checkbox" ng-model="asInfo.IsVPN" name="IsVPN">Use an OpenVPN connection for this AS</label>
+        <label>
+          <input type="checkbox" ng-model="asInfo.IsVPN" name="IsVPN" ng-disabled="asInfo.Type == 0">
+          Use an OpenVPN connection for this AS
+        </label>
     </div>
     <div class="form-group has-feedback" ng-show="!asInfo.IsVPN">
       <label>My host's public IP address</label>
       <input type="text" class="form-control" ng-model="asInfo.IP" name="IP"
-           placeholder="My host's public IP address" ng-required="!asInfo.IsVPN"
-           ng-pattern="/^(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/">
+             placeholder="My host's public IP address" ng-required="!asInfo.IsVPN"
+             ng-pattern="/^(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/"
+             ng-disabled="asInfo.Type == 0">
       <span class="glyphicon glyphicon-home form-control-feedback"></span>
     </div>
     <div class="form-group has-feedback">
       <label>Port where this AS accepts traffic</label>
       <input type="number" class="form-control" min="1024" max="65535" required
-             ng-model="asInfo.Port" name="Port" placeholder="Port (default: 50000)">
+             ng-model="asInfo.Port" name="Port" placeholder="Port (default: 50000)"
+             ng-disabled="asInfo.Type == 0">
       <span class="glyphicon glyphicon-log-in form-control-feedback"></span>
     </div>
 


### PR DESCRIPTION
Infrastructure ASes should not be modified through the normal user interface. 
For now, this PR disables configuration; later, we may want to add an admin interface to modify APs and infrastructure ASes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/157)
<!-- Reviewable:end -->
