### PR TITLE
Only transfer AccountID and Secret for admin users

### DIFF
--- a/controllers/api/admin.go
+++ b/controllers/api/admin.go
@@ -31,9 +31,15 @@ type AdminController struct {
 	controllers.HTTPController
 }
 
+type accountData struct {
+	AccountID     string
+	AccountSecret string
+}
+
 type adminPageData struct {
 	User         user
 	EmailMessage string
+	Account      accountData
 }
 
 type invitationInfo struct {
@@ -58,7 +64,7 @@ type invitationsData []invitationInfo
 var invitationsTemplate = "invitation.html"
 
 func (c AdminController) AdminInformation(w http.ResponseWriter, r *http.Request) {
-	user, err := populateUserData(r)
+	user, account, err := populateUserData(r)
 	if err != nil {
 		log.Printf("Error authenticating user: %v", err)
 		c.Forbidden(w, err, "Error authenticating user")
@@ -71,6 +77,7 @@ func (c AdminController) AdminInformation(w http.ResponseWriter, r *http.Request
 	adminData := adminPageData{
 		User:         user,
 		EmailMessage: string(text),
+		Account:      account,
 	}
 
 	c.JSON(&adminData, w, r)

--- a/controllers/api/login.go
+++ b/controllers/api/login.go
@@ -41,8 +41,6 @@ type user struct {
 	IsAdmin      bool
 	Account      string
 	Organisation string
-	AccountID    string
-	Secret       string
 }
 
 func (c *LoginController) Logout(w http.ResponseWriter, r *http.Request) {
@@ -153,7 +151,6 @@ func (c *LoginController) Login(w http.ResponseWriter, r *http.Request) {
 	user.FirstName = dbUser.FirstName
 	user.LastName = dbUser.LastName
 	user.IsAdmin = dbUser.IsAdmin
-	user.Account = dbUser.Account.Name
 	user.Organisation = dbUser.Account.Organisation
 
 	// clean up the password

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -170,7 +170,7 @@ func populateASStatusButtons(userEmail string) ([]asInfo, []apInfo, error) {
 }
 
 // generates the user-information struct to be used in dynamic HTML pages
-func populateUserData(r *http.Request) (u user, err error) {
+func populateUserData(r *http.Request) (u user, a accountData, err error) {
 	// get the current user session if present.
 	// if not then, abort
 	_, userSession, err := middleware.GetUserSession(r)
@@ -192,8 +192,11 @@ func populateUserData(r *http.Request) (u user, err error) {
 		IsAdmin:      storedUser.IsAdmin,
 		Account:      storedUser.Account.Name,
 		Organisation: storedUser.Account.Organisation,
-		AccountID:    storedUser.Account.AccountID,
-		Secret:       storedUser.Account.Secret,
+	}
+
+	a = accountData{
+		AccountID:     storedUser.Account.AccountID,
+		AccountSecret: storedUser.Account.Secret,
 	}
 
 	return
@@ -202,7 +205,7 @@ func populateUserData(r *http.Request) (u user, err error) {
 // API function that generates all information necessary for displaying the user page
 func (c *LoginController) UserInformation(w http.ResponseWriter, r *http.Request) {
 
-	user, err := populateUserData(r)
+	user, _, err := populateUserData(r)
 	if err != nil {
 		log.Println(err)
 		c.Forbidden(w, err, "Error authenticating user: Not logged in")

--- a/public/js/controllers/admin.js
+++ b/public/js/controllers/admin.js
@@ -12,6 +12,7 @@ angular.module('scionApp')
                     function (data) {
                         console.log(data);
                         $rootScope.user = data["User"];
+                        $scope.account = data["Account"];
                         // option to allow the email template to be changed
                         // $scope.emailTemplate = data["EmailTemplate"];
                         $scope.organisation = $rootScope.user["Organisation"];

--- a/public/partials/admin.html
+++ b/public/partials/admin.html
@@ -3,8 +3,8 @@
   <h3>Welcome to the SCIONLab Admin Interface!</h3>
   <p>Your account credentials are the following:</p>
 
-  <p><strong>AccountI:</strong> {{user.AccountID}}</p>
-  <p><strong>Secret:</strong> {{user.Secret}}</p>
+  <p><strong>AccountID:</strong> {{account.AccountID}}</p>
+  <p><strong>Secret:</strong> {{account.AccountSecret}}</p>
 
   <div class="spacer"></div>
   <h3>Email invitations</h3>


### PR DESCRIPTION
So far, AccountID and Secret were transferred as JSON data also for normal users, even though they were not displayed.
The situation is clarified by this PR such that these data are only sent for admin users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/159)
<!-- Reviewable:end -->
