### PR TITLE
Check owner of Attachment Point before giving access to APIs

### DIFF
--- a/controllers/middleware/authorization.go
+++ b/controllers/middleware/authorization.go
@@ -32,11 +32,11 @@ var (
 // TODO(mlegner): We need an additional authorization handler that checks if the account is an admin
 func checkAccountSecret(r *http.Request) bool {
 	vars := mux.Vars(r)
-	account_id := vars["account_id"]
+	accountID := vars["account_id"]
 	secret := vars["secret"]
 	// In this case we are receiving a request with account_id and secret params
-	if account_id != "" && secret != "" {
-		if account, err := models.FindAccountByAccountIDAndSecret(account_id, secret); err == nil &&
+	if accountID != "" && secret != "" {
+		if account, err := models.FindAccountByAccountIDAndSecret(accountID, secret); err == nil &&
 			account != nil {
 			// proceed with the next handler
 			return true
@@ -45,11 +45,11 @@ func checkAccountSecret(r *http.Request) bool {
 	}
 
 	// try with standard Golang parameters
-	account_id = r.URL.Query().Get("account_id")
+	accountID = r.URL.Query().Get("account_id")
 	secret = r.URL.Query().Get("secret")
 
-	if account_id != "" && secret != "" {
-		if account, err := models.FindAccountByAccountIDAndSecret(account_id, secret); err == nil &&
+	if accountID != "" && secret != "" {
+		if account, err := models.FindAccountByAccountIDAndSecret(accountID, secret); err == nil &&
 			account != nil {
 			// proceed with the next handler
 			return true

--- a/main.go
+++ b/main.go
@@ -207,8 +207,10 @@ func main() {
 
 	//SCIONBox API
 	router.Handle("/api/as/initBox", loggingChain.ThenFunc(scionBoxController.InitializeBox))
-	router.Handle("/api/as/connectBox/{account_id}/{secret}", apiChain.ThenFunc(scionBoxController.ConnectNewBox))
-	router.Handle("/api/as/heartbeat/{account_id}/{secret}", apiChain.ThenFunc(scionBoxController.HeartBeatFunction))
+	router.Handle("/api/as/connectBox/{account_id}/{secret}", apiChain.ThenFunc(
+		scionBoxController.ConnectNewBox))
+	router.Handle("/api/as/heartbeat/{account_id}/{secret}", apiChain.ThenFunc(
+		scionBoxController.HeartBeatFunction))
 
 	// ==========================================================
 	// SCION Web API

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -483,6 +483,26 @@ func FindSCIONLabASesByUserEmailAndType(email string, Type uint8) ([]SCIONLabAS,
 	return ases, err
 }
 
+// Find SCIONLabASes by AccountID; returns a slice of IA strings
+func FindSCIONLabASesByAccountID(accountID string) (asStrings []string, err error) {
+	a, err := FindAccountByAccountID(accountID)
+	if err != nil {
+		return
+	}
+	o.LoadRelated(a, "Users")
+	for _, u := range a.Users {
+		var ases []SCIONLabAS
+		ases, err = FindSCIONLabASesByUserEmail(u.Email)
+		if err != nil {
+			return
+		}
+		for _, as := range ases {
+			asStrings = append(asStrings, as.IA())
+		}
+	}
+	return
+}
+
 // Find SCIONLabAS by the IA string
 func FindSCIONLabASByIAString(ia string) (*SCIONLabAS, error) {
 	as := new(SCIONLabAS)


### PR DESCRIPTION
So far, only a valid AccountID/Secret combination was required to query the coordinator for updates for an Attachment Point.
However, it was not checked if the specified account is actually the owner of that Attachment Point.
This is solved by this PR by adding additional checks whenever the API is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/160)
<!-- Reviewable:end -->
