### PR TITLE
Finish database cleanup and support different ports of VPN servers

### DIFF
--- a/controllers/api/scion_lab_vpn.go
+++ b/controllers/api/scion_lab_vpn.go
@@ -54,6 +54,7 @@ func (s *SCIONLabASController) generateVPNConfig(asInfo *SCIONLabASInfo) error {
 
 	config := map[string]string{
 		"ServerIP":   asInfo.VPNServerIP,
+		"ServerPort": fmt.Sprintf("%v", asInfo.VPNServerPort),
 		"CACert":     string(caCert),
 		"ClientCert": clientCertStr[startCert:],
 		"ClientKey":  string(clientKey),

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -42,9 +42,9 @@ type asInfo struct {
 }
 
 type apInfo struct {
-	ISD   string
-	IA    string
-	Label string
+	ISD    string
+	Label  string
+	HasVPN bool // Does this AP have a running VPN server
 }
 
 type buttonConfiguration struct {
@@ -65,15 +65,15 @@ type uiButtons struct {
 type userPageData struct {
 	User    user
 	MaxASes int // maximal number of ASes this user can have
-	APs     []apInfo
+	APs     map[string]apInfo
 	ASInfos []asInfo
 }
 
 // generates the structs containing information about the user's AS and the
 // configuration of UI buttons
-func populateASStatusButtons(userEmail string) ([]asInfo, []apInfo, error) {
+func populateASStatusButtons(userEmail string) ([]asInfo, map[string]apInfo, error) {
 	asInfos := []asInfo{}
-	apInfos := []apInfo{}
+	apInfos := map[string]apInfo{}
 	ases, err := models.FindSCIONLabASesByUserEmail(userEmail)
 	if err != nil {
 		return asInfos, apInfos, err
@@ -83,13 +83,12 @@ func populateASStatusButtons(userEmail string) ([]asInfo, []apInfo, error) {
 		return asInfos, apInfos, err
 	}
 	for _, ap := range aps {
-		// TODO(mlegner): Add label
 		apI := apInfo{
-			ISD:   fmt.Sprintf("ISD %v", ap.ISD),
-			IA:    ap.IA(),
-			Label: ap.String(),
+			ISD:    fmt.Sprintf("ISD %v", ap.ISD),
+			Label:  ap.String(),
+			HasVPN: ap.AP.HasVPN,
 		}
-		apInfos = append(apInfos, apI)
+		apInfos[ap.IA()] = apI
 	}
 	for _, as := range ases {
 		buttons := uiButtons{

--- a/main.go
+++ b/main.go
@@ -15,14 +15,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"time"
-
-	"encoding/json"
-	"io/ioutil"
 
 	"github.com/astaxie/beego/orm"
 	"github.com/didip/tollbooth"

--- a/models/events.go
+++ b/models/events.go
@@ -29,10 +29,10 @@ type JoinRequest struct {
 	ID            uint64 `orm:"column(id);auto;pk"`
 	RequestID     uint64 `orm:"column(request_id)"`
 	Info          string // free form text for the reply
-	ISDToJoin     int    `orm:"column(isd_to_join)"` // the ISD that the sender wants to join
-	JoinAsACoreAS bool   // whether to join the ISD as a core AS
-	RequesterID   string `orm:"column(requester_id)"` // the key to identify which account made the request
-	RespondIA     string // the ISD-AS which should respond to the request
+	ISDToJoin     int    `orm:"column(isd_to_join)"`       // the ISD that the sender wants to join
+	JoinAsACoreAS bool   `orm:"column(join_as_a_core_as)"` // whether to join the ISD as a core AS
+	RequesterID   string `orm:"column(requester_id)"`      // the key to identify which account made the request
+	RespondIA     string `orm:"column(respond_ia)"`        // the ISD-AS which should respond to the request
 	SigPubKey     string // signing public key
 	EncPubKey     string // encryption public key
 	Status        string
@@ -84,12 +84,12 @@ type JoinReply struct {
 	Info                 string // free form text for the reply
 	RequesterID          string `orm:"column(requester_id)"` // the string to identify which account made the request
 	Status               string
-	JoiningIA            string
-	IsCore               bool // whether the new AS joins as core
-	RespondIA            string
-	JoiningIACertificate string `orm:"type(text)"` // certificate of the newly joining AS
-	RespondIACertificate string `orm:"type(text)"` // certificate of the responding AS
-	TRC                  string `orm:"type(text)"`
+	JoiningIA            string `orm:"column(joining_ia)"`
+	IsCore               bool   // whether the new AS joins as core
+	RespondIA            string `orm:"column(respond_ia)"`
+	JoiningIACertificate string `orm:"column(joining_ia_certificate);type(text)"`    // certificate of the newly joining AS
+	RespondIACertificate string `orm:"column(responding_ia_certificate);type(text)"` // certificate of the responding AS
+	TRC                  string `orm:"column(trc);type(text)"`
 }
 
 func FindJoinReply(requester string, req_id uint64) (*JoinReply, error) {
@@ -127,14 +127,14 @@ type ConnRequest struct {
 	RequestID            uint64   `orm:"column(request_id)"`
 	Account              *Account `orm:"rel(fk)"` // account sending the connection request
 	Status               string
-	RequestIA            string
-	RespondIA            string
+	RequestIA            string `orm:"column(request_ia)"`
+	RespondIA            string `orm:"column(respond_ia)"`
 	RequesterCertificate string `orm:"type(text)"`
 	Info                 string // free form text motivation for the request
 	OverlayType          string
-	IP                   string
+	IP                   string `orm:"column(ip)"`
 	Port                 uint64
-	MTU                  uint64 // bytes
+	MTU                  uint64 `orm:"column(mtu)"` // bytes
 	Bandwidth            uint64 // kbps
 	LinkType             string
 	Timestamp            string // UTC ISO 8601 format string, 1s precision
@@ -175,13 +175,13 @@ type ConnReply struct {
 	Info        string   // free form text for the reply
 	Account     *Account `orm:"rel(fk)"` // account which should receive the connection reply
 	Status      string
-	RespondIA   string
-	RequestIA   string
+	RespondIA   string `orm:"column(respond_ia)"`
+	RequestIA   string `orm:"column(request_ia)"`
 	Certificate string `orm:"type(text)"`
 	OverlayType string
-	IP          string
+	IP          string `orm:"column(ip)"`
 	Port        uint64
-	MTU         uint64 // bytes
+	MTU         uint64 `orm:"column(mtu)"` // bytes
 	Bandwidth   uint64 // kbps
 }
 

--- a/models/scion_box.go
+++ b/models/scion_box.go
@@ -20,11 +20,11 @@ import (
 
 type SCIONBox struct {
 	ID             uint64 `orm:"column(id);auto;pk"`
-	MAC            string
+	MAC            string `orm:"column(mac)"`
 	UserEmail      string
-	ISD            int `orm:"default(0)"`
-	AS             int `orm:"default(0)"`
-	InternalIP     string
+	ISD            int    `orm:"column(isd);default(0)"`
+	AS             int    `orm:"column(as);default(0)"`
+	InternalIP     string `orm:"column(internal_ip)"`
 	Shipping       string
 	OpenPorts      uint16 `orm:"default(0)"` // Number of free ports UDP ports starting from StartPort
 	StartPort      uint16 `orm:"default(50000)"`
@@ -70,8 +70,8 @@ func (sb *SCIONBox) Remove() error {
 }
 
 type ISDLocation struct {
-	Id        uint64 `orm:"column(id);auto;pk"`
-	ISD       int
+	ID        uint64 `orm:"column(id);auto;pk"`
+	ISD       int    `orm:"column(isd)"`
 	Country   string
 	Continent string
 }

--- a/models/user.go
+++ b/models/user.go
@@ -59,7 +59,7 @@ type user struct {
 	LastName         string
 	Verified         bool     // whether the user verified the email
 	IsAdmin          bool     // whether the user is marked as admin
-	VerificationUUID string   // uuid sent to user to verify email
+	VerificationUUID string   `orm:"column(verification_uuid)"` // uuid sent to user to verify email
 	Account          *Account `orm:"rel(fk);index"`
 	Created          time.Time
 	Updated          time.Time

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -81,3 +81,14 @@ const scionApp = angular.module('scionApp', [
             };
         }]);
 })();
+
+scionApp.filter('toArray', function () {
+    return function (obj) {
+        if (!(obj instanceof Object)) {
+            return obj;
+        }
+        return Object.keys(obj).map(function (key) {
+            return Object.defineProperty(obj[key], '$key', {__proto__: null, value: key});
+        });
+    }
+});

--- a/public/js/controllers/user.js
+++ b/public/js/controllers/user.js
@@ -95,6 +95,12 @@ scionApp
                     });
             };
 
+            $scope.disableVPN = function (ap) {
+                if (!$scope.aps[ap]["HasVPN"]) {
+                    $scope.asInfo["IsVPN"] = false;
+                }
+            };
+
             $scope.downloadSCIONLabAS = function (asInfo) {
                 $scope.error2 = "";
                 $scope.message2 = "";

--- a/public/partials/user.html
+++ b/public/partials/user.html
@@ -69,8 +69,8 @@
     <div class="form-group has-feedback">
       <label>Attachment point to connect to</label>
         <select name="AP" class="form-control dropdown-toggle" ng-model="asInfo.AP"
-                ng-options="x.IA as x.Label group by x.ISD for x in aps | orderBy: ['ISD', 'IA']"
-                ng-disabled="asInfo.Type == 0" required>
+                ng-options="i as x.Label group by x.ISD for (i, x) in aps | toArray | orderBy: ['ISD', 'Label']"
+                ng-disabled="asInfo.Type == 0" required ng-change="disableVPN(asInfo.AP)">
         </select>
       <span class="glyphicon glyphicon-cloud form-control-feedback"></span>
     </div>
@@ -92,9 +92,10 @@
         </label>
       </div>
     </div>
-    <div class="form-group checkbox">
+    <div class="form-group checkbox" ng-hide="!aps[asInfo.AP].HasVPN">
         <label>
-          <input type="checkbox" ng-model="asInfo.IsVPN" name="IsVPN" ng-disabled="asInfo.Type == 0">
+          <input type="checkbox" ng-model="asInfo.IsVPN" name="IsVPN"
+                 ng-disabled="asInfo.Type == 0">
           Use an OpenVPN connection for this AS
         </label>
     </div>

--- a/public/partials/user.html
+++ b/public/partials/user.html
@@ -65,11 +65,12 @@
     {{asInfo.ASText}}
   </strong>
   <p></p>
+  <!-- The asInfo.Type is enumerated as INFRASTRUCTURE: 0, VM: 1, DEDICATED: 2, BOX: 3 -->
   <form ng-show="asInfo" name="scionLabASForm">
     <div class="form-group has-feedback">
       <label>Attachment point to connect to</label>
         <select name="AP" class="form-control dropdown-toggle" ng-model="asInfo.AP"
-                ng-options="i as x.Label group by x.ISD for (i, x) in aps | toArray | orderBy: ['ISD', 'Label']"
+                ng-options="i as x.Label group by x.ISD for (i, x) in aps"
                 ng-disabled="asInfo.Type == 0" required ng-change="disableVPN(asInfo.AP)">
         </select>
       <span class="glyphicon glyphicon-cloud form-control-feedback"></span>

--- a/templates/client.conf.tmpl
+++ b/templates/client.conf.tmpl
@@ -8,7 +8,7 @@ dev tun
 proto udp
 
 # IP and port of the server
-remote {{.ServerIP}} 1194
+remote {{.ServerIP}} {{.ServerPort}}
 
 # Keep trying indefinitely to resolve the
 # host name of the OpenVPN server.


### PR DESCRIPTION
This PR finishes the job of #156 by fixing all remaining database column names.
In addition, it makes it possible to specify the port used for openVPN servers and allows APs to not offer VPN connection at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/161)
<!-- Reviewable:end -->
