### PR TITLE
Fix bug when failing authentication

### DIFF
--- a/controllers/api/scion_lab_ap.go
+++ b/controllers/api/scion_lab_ap.go
@@ -99,6 +99,7 @@ func (s *SCIONLabASController) GetUpdatesForAP(w http.ResponseWriter, r *http.Re
 	apIA, err := s.checkAuthorization(r)
 	if err != nil {
 		s.Forbidden(w, err, "The account is not authorized for this AP")
+		return
 	}
 
 	cns, err := models.FindRespondConnectionInfoByIA(apIA)


### PR DESCRIPTION
Small bug: when failing authentication we want to exit the function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/167)
<!-- Reviewable:end -->
