### PR TITLE
Bugfix: Panic when calling `getUpdatesForAP` with non-existent IA

### DIFF
--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -180,6 +180,9 @@ func (cn *Connection) Update() error {
 
 func (ap *AttachmentPoint) getConnections() ([]*Connection, error) {
 	_, err := o.LoadRelated(ap, "Connections")
+	if err == orm.ErrNoRows {
+		return []*Connection{}, nil
+	}
 	return ap.Connections, err
 }
 
@@ -224,10 +227,11 @@ func (as *SCIONLabAS) GetFreeVPNIP() (string, error) {
 
 // Only returns the connections of the AS in its function as the joining AS
 func (as *SCIONLabAS) getJoinConnections() ([]*Connection, error) {
-	if _, err := o.LoadRelated(as, "Connections"); err != nil {
-		return nil, err
+	_, err := o.LoadRelated(as, "Connections")
+	if err == orm.ErrNoRows {
+		return []*Connection{}, nil
 	}
-	return as.Connections, nil
+	return as.Connections, err
 }
 
 // Only returns the connections of the AS in its function as an AP

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -264,7 +264,9 @@ func (cn *Connection) getJoinAS() *SCIONLabAS {
 
 func (cn *Connection) getRespondAS() *SCIONLabAS {
 	ap := new(AttachmentPoint)
-	o.QueryTable(ap).Filter("ID", cn.RespondAP.ID).RelatedSel().One(ap)
+	if err := o.QueryTable(ap).Filter("ID", cn.RespondAP.ID).RelatedSel().One(ap); err != nil {
+		return nil
+	}
 	o.LoadRelated(ap, "AS")
 	return ap.AS
 }
@@ -506,13 +508,15 @@ func FindSCIONLabASesByAccountID(accountID string) (asStrings []string, err erro
 // Find SCIONLabAS by the IA string
 func FindSCIONLabASByIAString(ia string) (*SCIONLabAS, error) {
 	as := new(SCIONLabAS)
-	IA, err1 := addr.IAFromString(ia)
-	if err1 != nil {
-		return nil, err1
+	IA, err := addr.IAFromString(ia)
+	if err != nil {
+		return nil, err
 	}
-	err := o.QueryTable(as).Filter("ISD", IA.I).Filter("ASID", IA.A).RelatedSel().One(as)
+	if err := o.QueryTable(as).Filter("ISD", IA.I).Filter("ASID", IA.A).RelatedSel().One(as); err != nil {
+		return nil, err
+	}
 	o.LoadRelated(as, "AP")
-	return as, err
+	return as, nil
 }
 
 // Find SCIONLabAS by the ISD AS int


### PR DESCRIPTION
This PR addresses issue #168.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/169)
<!-- Reviewable:end -->
