### PR TITLE
Bugfix: Delete old connection when connecting to a different Attachment Point

### DIFF
--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -636,6 +636,21 @@ func (asInfo *ASInfo) String() string {
 	return utility.IAString(asInfo.ISD, asInfo.ASID)
 }
 
+// Delete a connection between specified ASes
+func (as *SCIONLabAS) DeleteConnectionToAP(apIA string) error {
+	if _, err := o.LoadRelated(as, "Connections"); err != nil {
+		return err
+	}
+	for _, cn := range as.Connections {
+		o.LoadRelated(cn, "RespondAP")
+		o.LoadRelated(cn.RespondAP, "AS")
+		if apIA == cn.RespondAP.AS.IA() {
+			return cn.Delete()
+		}
+	}
+	return fmt.Errorf("Did not find a connection between AS %v and AP %v", as.IA(), apIA)
+}
+
 func (as *SCIONLabAS) Delete() error {
 	_, err := o.Delete(as)
 	return err


### PR DESCRIPTION
There is a bug when a user switches to a different Attachment Point for one of their ASes.
In this case, the new connection is correctly inserted into the database but the old one is not deleted.
This problem is fixed by this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/172)
<!-- Reviewable:end -->
