### PR TITLE
Bugfix: Send AS confirmations to correct user.

### DIFF
--- a/controllers/api/scion_lab_ap.go
+++ b/controllers/api/scion_lab_ap.go
@@ -238,8 +238,7 @@ func (s *SCIONLabASController) processConfirmedUpdatesFromAP(apAS *models.SCIONL
 			cn_db.Status = models.INACTIVE
 			cn_db.BRID = 0 // Set BRID to 0 for inactive connections
 		default:
-			log.Printf("Unsupported action \"%v\" for AS %v. User: %v", action, ia,
-				cn_db.NeighborUser)
+			log.Printf("Unsupported action \"%v\" for AS %v. User: %v", action, ia, as.UserEmail)
 			failedConfirmations = append(failedConfirmations, ia)
 			continue
 		}
@@ -249,7 +248,7 @@ func (s *SCIONLabASController) processConfirmedUpdatesFromAP(apAS *models.SCIONL
 			failedConfirmations = append(failedConfirmations, ia)
 			continue
 		}
-		emails = append(emails, emailConfirmation{cn_db.NeighborUser, action})
+		emails = append(emails, emailConfirmation{as.UserEmail, action})
 
 	}
 	for _, e := range emails {


### PR DESCRIPTION
Due to a bug, confirmation emails were sent to the owner of the Attachment Point instead of the user. This is fixed here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/179)
<!-- Reviewable:end -->
