### PR TITLE
Better version checking.

### DIFF
--- a/vagrant/run.sh
+++ b/vagrant/run.sh
@@ -33,16 +33,6 @@ run_osx() {
     run_vagrant
 }
 
-add_vb_vagrant_sources() {\
-    # add source and update only once, for performance reasons
-    if [ -z "$add_vb_vagrant_sources_singleton" ]; then
-        sudo bash -c 'echo deb http://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
-        sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
-        sudo apt-get update
-        add_vb_vagrant_sources_singleton=1
-    fi
-}
-
 # version less or equal. E.g. verleq 1.9 2.0.8  == true (1.9 <= 2.0.8)
 verleq() {
     [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
@@ -52,11 +42,14 @@ run_linux() {
     if [[ -f "/usr/bin/apt-get" && -f "/usr/bin/dpkg" ]]
     then
         echo "[SCIONLabVM] Given system: LINUX"
-        if dpkg --get-selections | grep -q "^virtualbox.*[[:space:]]\{1,\}install$" >/dev/null; then
+        if dpkg --get-selections | grep -q "^$VB.*[[:space:]]\{1,\}install$" >/dev/null; then
             echo "[SCIONLabVM] $VB is already installed"
         else
             echo "[SCIONLabVM] Installing $VB"
-            add_vb_vagrant_sources
+            # add source and update only once, for performance reasons
+            sudo bash -c 'echo deb http://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
+            sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
+            sudo apt-get update
             sudo apt-get --no-remove --yes install $VB
         fi
         VERS=$(vagrant version | grep "Installed Version:" | sed -n 's/^Installed Version: \(.*\)$/\1/p')


### PR DESCRIPTION
Virtualbox can now be installed from Oracle directly (different package name, virtualbox-VERSION).
Vagrant can now be installed past 1.9 (e.g. 2.0.X).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/195)
<!-- Reviewable:end -->
