### PR TITLE
Fix map fcn when input had ISD already mapped.

### DIFF
--- a/utility/utility.go
+++ b/utility/utility.go
@@ -218,14 +218,16 @@ func SendJSONError(object interface{}, w http.ResponseWriter) error {
 // The convention for scionlab user ASes is to start from exactly ffaa:0001:0000, meaning
 // we reserve ffaa:0000:0000 to ffaa:0000:ffff for infrastructure.
 func MapOldIAToNewOne(ISDid addr.ISD, ASid addr.AS) addr.IA {
-	var I addr.ISD
-	var A addr.AS
-	if ISDid > 0 && ISDid < 22 && ASid > 1000 && ASid < 10000 {
-		if ISDid >= 20 && ISDid <= 21 {
-			ISDid += 40 - ScionLabISDOffsetAddr
-		}
-		I, A = ISDid+ScionLabISDOffsetAddr, ASid-1000+ScionlabUserASOffsetAddr
+	isdOffset := addr.ISD(0)
+	if ISDid >= 1 && ISDid <= 8 { // add 16 iff old ISD. I.e. ISD == 1,2,3,4,5,6,7,8 .
+		isdOffset = ScionLabISDOffsetAddr
 	}
-
-	return addr.IA{I: I, A: A}
+	asOffset := addr.AS(0)
+	if ASid > 1000 && ASid < 10000 {
+		asOffset = ScionlabUserASOffsetAddr - 1000
+	}
+	if ISDid > 0 && ISDid < 64 && ASid+asOffset > 10000 {
+		return addr.IA{I: ISDid + isdOffset, A: ASid + asOffset}
+	}
+	return addr.IA{I: 0, A: 0}
 }

--- a/utility/utility_test.go
+++ b/utility/utility_test.go
@@ -220,11 +220,12 @@ var mapOldIAToNewOneTests = []struct {
 	toISD   addr.ISD
 	toAS    addr.AS
 }{
-	{20, 1001, 60, 0xFFAA00010001},
+	// test only ISD-ASes that could show up in the Coordinator
 	{1, 1001, 17, 0xFFAA00010001},
 	{2, 1001, 18, 0xFFAA00010001},
 	{0, 1001, 0, 0},
-	{42, 1001, 0, 0},
+	{17, 1001, 17, 0xFFAA00010001},
+	{17, 0xFFAA00010001, 17, 0xFFAA00010001},
 	{1, 1000, 0, 0},
 	{1, 2001, 17, 0xFFAA000103E9}, // scionbox valid
 	{8, 1017, 24, 0xFFAA00010011},

--- a/utility/utility_test.go
+++ b/utility/utility_test.go
@@ -221,14 +221,17 @@ var mapOldIAToNewOneTests = []struct {
 	toAS    addr.AS
 }{
 	// test only ISD-ASes that could show up in the Coordinator
-	{1, 1001, 17, 0xFFAA00010001},
-	{2, 1001, 18, 0xFFAA00010001},
-	{0, 1001, 0, 0},
-	{17, 1001, 17, 0xFFAA00010001},
-	{17, 0xFFAA00010001, 17, 0xFFAA00010001},
-	{1, 1000, 0, 0},
-	{1, 2001, 17, 0xFFAA000103E9}, // scionbox valid
-	{8, 1017, 24, 0xFFAA00010011},
+	{1, 1001, 17, 0xFFAA00010001},            // old -> new
+	{2, 1001, 18, 0xFFAA00010001},            // old -> new
+	{1, 2001, 17, 0xFFAA000103E9},            // old -> new (scion boxes?)
+	{8, 1017, 24, 0xFFAA00010011},            // old -> new
+	{17, 0xFFAA00010001, 17, 0xFFAA00010001}, // new -> new (user AS)
+	{16, 0xFFAA00001001, 16, 0xFFAA00001001}, // new -> new (infrastructure)
+	{30, 0xFFAA00001E01, 30, 0xFFAA00001E01}, // new -> new (infrastructure)
+	{17, 1001, 17, 0xFFAA00010001},           // mixed old/new -> new
+	{20, 1001, 20, 0xFFAA00010001},           // mixed old/new -> new (ISDs 20 and 21 are always considered new)
+	{0, 1001, 0, 0},                          // invalid ISD -> invalid
+	{1, 1000, 0, 0},                          // invalid (out of SCIONLab range) -> invalid
 }
 
 func TestMapOldIAToNewOne(t *testing.T) {


### PR DESCRIPTION
Right now we have several ASes that have their ISD already mapped, because the coordinator
allows to change its AP. If we try to map them, they will fail. Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/249)
<!-- Reviewable:end -->
