### PR TITLE
Sync time big steps

### DIFF
--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -264,6 +264,13 @@ then
         if ! egrep -- '^NTPD_OPTS=.*-g.*$' /etc/default/ntp >/dev/null; then
             sudo sed -i "s/^NTPD_OPTS='\(.*\)'/NTPD_OPTS=\'\\1\ -g'/g" /etc/default/ntp
         fi
+        if ! grep 'tinker panic 0' /etc/ntp.conf; then
+            # set panic limit to 0 (disable)
+            echo -e "tinker panic 0\n" | sudo tee -a /etc/ntp.conf >/dev/null
+        fi
+        if ! egrep -- '^pool.*maxpoll.*$' /etc/ntp.conf; then
+            sudo sed -i 's/\(pool .*\)$/\1 minpoll 1 maxpoll 6/g' /etc/ntp.conf
+        fi
         sudo systemctl restart ntp || true
     fi
 else

--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -251,6 +251,15 @@ then
     
     sudo systemctl start scionupgrade.timer
     sudo systemctl start scionupgrade.service
+
+    # registering the upgrade service also means "manage SCION", including keep time sync'ed
+    sudo apt-get install -y --no-remove ntp || true
+    sudo systemctl enable ntp || true
+    sudo systemctl restart ntp || true
+    if ! egrep -- '^NTPD_OPTS=.*-g.*$' /etc/default/ntp >/dev/null; then
+        sudo sed -i "s/^NTPD_OPTS='\(.*\)'/NTPD_OPTS=\'\\1\ -g'/g" /etc/default/ntp
+        sudo systemctl restart ntp || true
+    fi
 else
     echo "SCION periodic upgrade service and timer files are not provided."
 fi

--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -254,8 +254,13 @@ then
 
     # registering the upgrade service also means "manage SCION", including keep time sync'ed
     sudo apt-get install -y --no-remove ntp || true
+    sudo sed -i -- 's/^\(\s*start-stop-daemon\s*--start\s*--quiet\s*--oknodo\s*--exec\s*\/usr\/sbin\/VBoxService\)$/\1 -- --disable-timesync/g' /etc/init.d/virtualbox-guest-utils || true
+    # restart virtual box guest services and NTPd :
+    sudo systemctl daemon-reload || true
+    sudo systemctl restart virtualbox-guest-utils
     sudo systemctl enable ntp || true
     sudo systemctl restart ntp || true
+    # we want ntpd to use the -g flag (no panic threshold):
     if ! egrep -- '^NTPD_OPTS=.*-g.*$' /etc/default/ntp >/dev/null; then
         sudo sed -i "s/^NTPD_OPTS='\(.*\)'/NTPD_OPTS=\'\\1\ -g'/g" /etc/default/ntp
         sudo systemctl restart ntp || true

--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -252,17 +252,18 @@ then
     sudo systemctl start scionupgrade.timer
     sudo systemctl start scionupgrade.service
 
-    # registering the upgrade service also means "manage SCION", including keep time sync'ed
-    sudo apt-get install -y --no-remove ntp || true
-    sudo sed -i -- 's/^\(\s*start-stop-daemon\s*--start\s*--quiet\s*--oknodo\s*--exec\s*\/usr\/sbin\/VBoxService\)$/\1 -- --disable-timesync/g' /etc/init.d/virtualbox-guest-utils || true
-    # restart virtual box guest services and NTPd :
-    sudo systemctl daemon-reload || true
-    sudo systemctl restart virtualbox-guest-utils
-    sudo systemctl enable ntp || true
-    sudo systemctl restart ntp || true
-    # we want ntpd to use the -g flag (no panic threshold):
-    if ! egrep -- '^NTPD_OPTS=.*-g.*$' /etc/default/ntp >/dev/null; then
-        sudo sed -i "s/^NTPD_OPTS='\(.*\)'/NTPD_OPTS=\'\\1\ -g'/g" /etc/default/ntp
+    if [ -d "/vagrant" ]; then # iff this is a VM
+        # registering the upgrade service also means "manage SCION", including keep time sync'ed
+        sudo apt-get install -y --no-remove ntp || true
+        sudo sed -i -- 's/^\(\s*start-stop-daemon\s*--start\s*--quiet\s*--oknodo\s*--exec\s*\/usr\/sbin\/VBoxService\)$/\1 -- --disable-timesync/g' /etc/init.d/virtualbox-guest-utils || true
+        # restart virtual box guest services and NTPd :
+        sudo systemctl daemon-reload || true
+        sudo systemctl restart virtualbox-guest-utils
+        sudo systemctl enable ntp || true
+        # we want ntpd to use the -g flag (no panic threshold):
+        if ! egrep -- '^NTPD_OPTS=.*-g.*$' /etc/default/ntp >/dev/null; then
+            sudo sed -i "s/^NTPD_OPTS='\(.*\)'/NTPD_OPTS=\'\\1\ -g'/g" /etc/default/ntp
+        fi
         sudo systemctl restart ntp || true
     fi
 else

--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -272,6 +272,19 @@ then
             sudo sed -i 's/\(pool .*\)$/\1 minpoll 1 maxpoll 6/g' /etc/ntp.conf
         fi
         sudo systemctl restart ntp || true
+        # system updates, ensure unattended-upgrades is installed
+        if ! dpkg-query -W --showformat='${Status}\n' unattended-upgrades|grep "install ok installed" >/dev/null; then
+            sudo apt-get install -f --no-remove unattended-upgrades
+        fi
+        if [ ! -f /etc/apt/apt.conf.d/51unattended-upgrades ]; then
+            echo "Configuring unattended-upgrades"
+            echo 'Unattended-Upgrade::Allowed-Origins {
+"${distro_id}:${distro_codename}-security";
+"${distro_id}ESM:${distro_codename}";
+};
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "02:00";' | sudo tee /etc/apt/apt.conf.d/51unattended-upgrades >/dev/null
+        fi
     fi
 else
     echo "SCION periodic upgrade service and timer files are not provided."

--- a/scion_upgrade_script.sh
+++ b/scion_upgrade_script.sh
@@ -58,7 +58,9 @@ check_system_files() {
             echo "ntpd restarted."
         fi
         # don't attempt to stop the scionupgrade service as this script is a child of it and will also be killed !
-        # if really needed, specify KillMode=none in the service file itself
+        # even with KillMode=none in the service file, restarting the service here would be really delicate, as it
+        # could basically hang forever if the service files don't update the version number correctly, and we would
+        # spawn a large number of processes one after the other, not doing anything but restarting the service.
         sudo systemctl daemon-reload
     fi
 }
@@ -139,6 +141,7 @@ else
     ./scion.sh stop || true
     ~/.local/bin/supervisorctl -c supervisor/supervisord.conf shutdown || true
     ./tools/zkcleanslate || true
+    sudo systemctl restart zookeeper || true
 
     echo "Reinstalling dependencies..."
     ./scion.sh clean || true

--- a/scion_upgrade_script.sh
+++ b/scion_upgrade_script.sh
@@ -43,6 +43,10 @@ check_system_files() {
             sudo systemctl enable ntp || true
             sudo systemctl restart ntp || true
         fi
+        if ! egrep -- '^NTPD_OPTS=.*-g.*$' /etc/default/ntp >/dev/null; then
+            sudo sed -i "s/^NTPD_OPTS='\(.*\)'/NTPD_OPTS=\'\\1\ -g'/g" /etc/default/ntp
+            sudo systemctl restart ntp || true
+        fi
         # don't attempt to stop the service as this script is a child of the service and will also be killed !
         # if really needed, specify KillMode=none in the service file itself
         sudo systemctl daemon-reload

--- a/scion_upgrade_script.sh
+++ b/scion_upgrade_script.sh
@@ -3,7 +3,7 @@
 set -e
 
 # version of the systemd files:
-SERVICE_CURRENT_VERSION="0.5"
+SERVICE_CURRENT_VERSION="0.6"
 
 # version less or equal. E.g. verleq 1.9 2.0.8  == true (1.9 <= 2.0.8)
 verleq() {

--- a/vagrant/scionupgrade.service
+++ b/vagrant/scionupgrade.service
@@ -1,4 +1,4 @@
-# SCION upgrade version 0.5
+# SCION upgrade version 0.6
 
 [Unit]
 Description=SCION infrastructure upgrade

--- a/vagrant/scionupgrade.service
+++ b/vagrant/scionupgrade.service
@@ -12,7 +12,7 @@ Type=oneshot
 RemainAfterExit=no
 User=_USER_
 WorkingDirectory=/tmp
-Environment="PATH=/home/_USER_/.local/bin:/home/_USER_/go/bin:/usr/local/go/bin:/home/_USER_/bin:/home/_USER_/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" "GOPATH=/home/_USER_/go" "SC=/home/_USER_/go/src/github.com/scionproto/scion/"
+Environment="PATH=/home/_USER_/.local/bin:/home/_USER_/go/bin:/usr/local/go/bin:/home/_USER_/bin:/home/_USER_/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" "GOPATH=/home/_USER_/go" "SC=/home/_USER_/go/src/github.com/scionproto/scion/" "PYTHONPATH=/home/_USER_/go/src/github.com/scionproto/scion/python:/home/_USER_/go/src/github.com/scionproto/scion"
 ExecStart=/usr/bin/scionupgrade.sh
 KillMode=none
 

--- a/vagrant/scionupgrade.timer
+++ b/vagrant/scionupgrade.timer
@@ -1,4 +1,4 @@
-# SCION upgrade version 0.5
+# SCION upgrade version 0.6
 
 [Unit]
 Description=Run SCION upgrade daily


### PR DESCRIPTION
Two changes here:
1) VMs are able to sync time correctly now after long periods suspended
2) ARM images update correctly

To test (1) start a VM, modify the /usr/bin/scionupgrade.sh script so it downloads from this branch instead of master, and run `sudo systemctl start scionupgrade.service` . Then pause the VM for 17 minutes and check the time (you may need to wait two minutes to get the correct time). Repeat the pausing/checking one more time.
To test (2) just download an old image from imagebuilder (Coordinator) (e.g. rPI 3) and replace /usr/bin/scionupgrade.sh wget with this branch instead of master. Then run `sudo systemctl start scionupgrade.service` .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/259)
<!-- Reviewable:end -->
