### PR TITLE
Use the ASId in the VM name.

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -723,7 +723,13 @@ func packageConfiguration(asInfo *SCIONLabASInfo) error {
 			portForwarding = fmt.Sprintf("config.vm.network \"forwarded_port\", "+
 				"guest: %[1]v, host: %[1]v, protocol: \"udp\"", asInfo.LocalPort)
 		}
-		data := map[string]string{"PORT_FORWARDING": portForwarding}
+		data := struct {
+			ASID           string
+			PortForwarding string
+		}{
+			ASID:           asInfo.LocalAS.ASID.FileFmt(),
+			PortForwarding: portForwarding,
+		}
 		if err := utility.FillTemplateAndSave("templates/Vagrantfile.tmpl",
 			data, filepath.Join(userPackagePath, "Vagrantfile")); err != nil {
 			return err

--- a/templates/Vagrantfile.tmpl
+++ b/templates/Vagrantfile.tmpl
@@ -16,14 +16,14 @@ Vagrant.configure(2) do |config|
   SCRIPT
   config.vm.box = "scion/ubuntu-16.04-64-scion"
   # BR port forwarding not necessary for OpenVPN setup and depends on connection
-  {{.PORT_FORWARDING}}
+  {{.PortForwarding}}
   config.vm.network "forwarded_port", guest: 31042, host: 31042, protocol: "udp"
   config.vm.network "forwarded_port", guest: 30041, host: 30041, protocol: "udp"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]
     vb.memory = "2048"
-    vb.name = "SCIONLabVM"
+    vb.name = "SCIONLabVM-{{.ASID}}"
   end
   config.vm.provision "shell", privileged: false, inline: $setup_scion
 end


### PR DESCRIPTION
Name is now "SCIONLabVM-{{.ASID}}" .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/261)
<!-- Reviewable:end -->
