### PR TITLE
Disable compression for coordinator http server

### DIFF
--- a/controllers/api/scion_box.go
+++ b/controllers/api/scion_box.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -444,8 +443,8 @@ func (s *SCIONBoxController) serveGen(userMail string, w http.ResponseWriter, r 
 	// Send the gzip file to the Box
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", "attachment; filename=scion_lab_"+fileName)
-	w.Header().Set("Content-Transfer-Encoding", "binary")
-	http.ServeContent(w, r, fileName, time.Now(), bytes.NewReader(data))
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Write(data)
 }
 
 //get the source IP from a http request

--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -805,8 +804,8 @@ func (s *SCIONLabASController) ReturnTarball(w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", "attachment; filename=scion_lab_"+fileName)
-	w.Header().Set("Content-Transfer-Encoding", "binary")
-	http.ServeContent(w, r, fileName, time.Now(), bytes.NewReader(data))
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Write(data);
 }
 
 func logAndSendError(w http.ResponseWriter, errorMsgFmt string, parms ...interface{}) string {
@@ -1021,8 +1020,8 @@ func (s *SCIONLabASController) RemapASDownloadGen(w http.ResponseWriter, r *http
 	log.Printf("Remap: serving new GEN for %v -> %v", asID, mappedIA)
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", "attachment; filename=scion_lab_"+fileName)
-	w.Header().Set("Content-Transfer-Encoding", "binary")
-	http.ServeContent(w, r, fileName, time.Now(), bytes.NewReader(data))
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Write(data)
 }
 
 // RemapASConfirmStatus receives confirmation from a user AS that they applied the mapping.

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/astaxie/beego/orm"
 	"github.com/didip/tollbooth"
 	"github.com/didip/tollbooth/limiter"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/netsec-ethz/scion-coord/config"
 	"github.com/netsec-ethz/scion-coord/controllers"
@@ -291,12 +290,11 @@ func main() {
 			}))
 
 		// listen to HTTPS requests
-		log.Fatal(http.Serve(autocert.NewListener(
-			config.HTTPHostAddress), handlers.CompressHandler(router)))
+		log.Fatal(http.Serve(autocert.NewListener(config.HTTPHostAddress), router))
 	} else {
 		fmt.Printf("Serving website on %v over HTTP\n", config.HTTPHostAddress)
 		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d",
-			config.HTTPBindAddress, config.HTTPBindPort), handlers.CompressHandler(router)))
+			config.HTTPBindAddress, config.HTTPBindPort), router))
 	}
 
 }


### PR DESCRIPTION
Using the gorilla.handler.CompressHandler was re-compressing the AS-configuration `.tar.gz`-files if the requests `Accept-Encoding` contains `gzip`.
Even though re-compressing seems redundant, the behaviour appeared to be correct (as `Content-Encoding: gzip` was set in the response). However, firefox appears to be confused by the combination with `Content-Type: application/gzip` and does not remove the second gzip-encoding before saving the file, making unpacking the tarball rather confusing.

Unfortunately I could not find a simple way to disable the compression specifically for downloading the tarballs, but given the small total size of the webpage it seems acceptable to turn this off globally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/266)
<!-- Reviewable:end -->
