### PR TITLE
Empty the gen cache whenever the update script is being run

### DIFF
--- a/scion_upgrade_script.sh
+++ b/scion_upgrade_script.sh
@@ -118,6 +118,9 @@ echo "Update branch is: ${UPDATE_BRANCH}"
 
 cd $SC
 
+echo "Emptying cache..."
+rm -f gen-cache/*
+
 git_username=$(git config user.name || true)
 if [ -z "$git_username" ]
 then


### PR DESCRIPTION
This addresses #274, at least for those user ASes that have updates enabled, and is a temporary solution for #275.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/276)
<!-- Reviewable:end -->
