### PR TITLE
Do not update database if generation of gen folder fails

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -287,6 +287,7 @@ func (s *SCIONLabASController) ConfigureSCIONLabAS(w http.ResponseWriter, r *htt
 	if err != nil {
 		log.Print(err)
 		s.Error500(w, err, "Error generating the configuration")
+		return
 	}
 
 	// Persist the relevant data into the DB
@@ -496,7 +497,7 @@ func (s *SCIONLabASController) updateDB(asInfo *SCIONLabASInfo) error {
 	if asInfo.IsNewConnection {
 		// flag the old connections for deletion:
 		if asInfo.OldAP != "" {
-			asInfo.LocalAS.FlagAllConnectionsToApToBeDeleted(asInfo.OldAP)
+			asInfo.LocalAS.FlagAllConnectionsToAPToBeDeleted(asInfo.OldAP)
 		}
 		// update the Connections table
 		newCn := models.Connection{
@@ -805,7 +806,7 @@ func (s *SCIONLabASController) ReturnTarball(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", "attachment; filename=scion_lab_"+fileName)
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
-	w.Write(data);
+	w.Write(data)
 }
 
 func logAndSendError(w http.ResponseWriter, errorMsgFmt string, parms ...interface{}) string {

--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -667,6 +667,9 @@ func generateLocalGen(asInfo *SCIONLabASInfo) error {
 	errOutput, _ := ioutil.ReadAll(cmdErr)
 	fmt.Printf("STDOUT generateLocalGen: %s\n", stdOutput)
 	fmt.Printf("ERROUT generateLocalGen: %s\n", errOutput)
+	if len(errOutput) != 0 {
+		return fmt.Errorf("generate local gen command reported errors: %s", errOutput)
+	}
 	return nil
 }
 

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -711,7 +711,7 @@ func (as *SCIONLabAS) DeleteConnectionFromDB(cnInfo *ConnectionInfo) error {
 	return cn.Delete()
 }
 
-func (as *SCIONLabAS) FlagAllConnectionsToApToBeDeleted(apIA string) error {
+func (as *SCIONLabAS) FlagAllConnectionsToAPToBeDeleted(apIA string) error {
 	cns, err := as.GetJoinConnectionInfo()
 	if err != nil {
 		return fmt.Errorf("Error looking up connections of SCIONLab AS for AS %v: %v", as.IAString(), err)


### PR DESCRIPTION
If generating the gen folder fails, we should return and not continue to update the database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/279)
<!-- Reviewable:end -->
