### PR TITLE
Fix vpn keys panic

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -825,7 +825,7 @@ func packageConfiguration(asInfo *SCIONLabASInfo) error {
 		}
 	}
 
-	cmd := exec.Command("tar", "zcvf", userPackageName+".tar.gz", userPackageName)
+	cmd := exec.Command("tar", "czf", userPackageName+".tar.gz", userPackageName)
 	cmd.Dir = PackagePath
 	err := cmd.Start()
 	if err == nil {

--- a/controllers/api/scion_lab_vpn.go
+++ b/controllers/api/scion_lab_vpn.go
@@ -93,16 +93,11 @@ func cleanVPNKeys(asInfo *SCIONLabASInfo) error {
 	userEmail := asInfo.LocalAS.UserEmail
 	userASID := asInfo.LocalAS.ASID
 	p := vpnKeyPath(userEmail, userASID)
-	_, err := os.Stat(p)
-	if err == nil {
-		err = os.Remove(p)
-	} else if !os.IsNotExist(err) {
-		err = fmt.Errorf("Cleaning VPN keys: error when stat on %s: %v", p, err)
-	}
-	if err != nil {
-		msg := fmt.Sprintf("Cleaning VPN keys: could not remove file under %s: %v", p, err)
-		log.Print(msg)
-		return fmt.Errorf(msg)
+	err := os.Remove(p)
+	if err != nil && !os.IsNotExist(err) {
+		err = fmt.Errorf("Cleaning VPN keys: could not remove file under %s: %v", p, err)
+		log.Print(err)
+		return err
 	}
 	p = vpnCertPath(userEmail, userASID)
 	_, err = os.Stat(p)

--- a/controllers/api/scion_lab_vpn.go
+++ b/controllers/api/scion_lab_vpn.go
@@ -124,7 +124,7 @@ func cleanVPNKeys(asInfo *SCIONLabASInfo) error {
 	// write contents to index.txt:
 	dbData, err := ioutil.ReadFile(dbFile)
 	if err != nil {
-		return nil
+		return err
 	}
 	id := vpnUserID(userEmail, userASID)
 	newData := []byte{}
@@ -139,10 +139,7 @@ func cleanVPNKeys(asInfo *SCIONLabASInfo) error {
 		return err
 	}
 	err = ioutil.WriteFile(dbFile, newData, 0664)
-	if err != nil {
-		return nil
-	}
-	return nil
+	return err
 }
 
 // Creates the keys for VPN setup

--- a/controllers/api/scion_lab_vpn.go
+++ b/controllers/api/scion_lab_vpn.go
@@ -118,12 +118,11 @@ func cleanVPNKeys(asInfo *SCIONLabASInfo) error {
 	}
 	// find the key in the TXT DB and remove it:
 	dbFile := filepath.Join(RSAKeyPath, "index.txt")
-	os.Remove(dbFile + ".bak")
-	dbData, err := ioutil.ReadFile(dbFile)
-	if err != nil {
-		return nil
+	if err = utility.RotateFiles(dbFile+".bak", 4); err != nil {
+		return err
 	}
-	err = ioutil.WriteFile(dbFile+".bak", dbData, 0664)
+	// write contents to index.txt:
+	dbData, err := ioutil.ReadFile(dbFile)
 	if err != nil {
 		return nil
 	}
@@ -135,6 +134,9 @@ func cleanVPNKeys(asInfo *SCIONLabASInfo) error {
 		if strings.Index(line, id) == -1 {
 			newData = append(newData, line...)
 		}
+	}
+	if err = os.Rename(dbFile, dbFile+".bak"); err != nil {
+		return err
 	}
 	err = ioutil.WriteFile(dbFile, newData, 0664)
 	if err != nil {


### PR DESCRIPTION
Missing tests!

Closes #282 . To test this PR: run the Coordinator but before re-configuring an existing AS, make the VPN cert file zero size. E.g. 
```
$ l netsec.test.email@gmail.com_ffaa_1_*
-rw------- 1 juan juan 3272 Oct  3 17:47 netsec.test.email@gmail.com_ffaa_1_2.key
-rw-rw-r-- 1 juan juan 1801 Oct  3 17:47 netsec.test.email@gmail.com_ffaa_1_2.csr
-rw-rw-r-- 1 juan juan 8273 Oct  3 17:47 netsec.test.email@gmail.com_ffaa_1_2.crt
$ rm netsec.test.email@gmail.com_ffaa_1_2.crt
$ touch netsec.test.email@gmail.com_ffaa_1_2.crt
```
This mimics a situation we have in the Coordinator (due to missing entries in `index.txt`, but another story).
Then re-configure the AS (e.g. `ffaa:1:2`) to use VPN. Coordinator will recreate the VPN keys (completely removing the private and public keys, and the entry in `index.txt` if it's there) and use them.
Of course the deployed `client.conf` (and AS) should work just fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/281)
<!-- Reviewable:end -->
