### PR TITLE
Use the right go binary directory in service files

### DIFF
--- a/scripts/install-scion-coord.sh
+++ b/scripts/install-scion-coord.sh
@@ -154,10 +154,10 @@ if [ -f "scion-coord.service" ]; then
 fi
 tmpfile=$(mktemp)
 cp "$files/scion-coord.service" "$tmpfile"
-sed -i -- "s/_USER_/$USER/g" "$tmpfile"
+sed -i "s|_USER_|$USER|g;s|/usr/local/go/bin|$(dirname $(which go))|g" "$tmpfile"
 sudo cp "$tmpfile" "scion-coord.service"
 cp "$files/unit-status-mail@.service" "$tmpfile"
-sed -i -- "s/_USER_/$USER/g" "$tmpfile"
+sed -i "s|_USER_|$USER|g;s|/usr/local/go/bin|$(dirname $(which go))|g" "$tmpfile"
 sudo cp "$tmpfile" "unit-status-mail@.service"
 popd >/dev/null
 sudo cp "$files/emailer.py" "/usr/local/bin/emailer"


### PR DESCRIPTION
Service files have a PATH exported section. Ensure it contains the right path for the `go` binaries.
There were some service files left behind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/285)
<!-- Reviewable:end -->
