### PR TITLE
Allow to use a wider VPN IP range

### DIFF
--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -260,12 +260,11 @@ func (as *SCIONLabAS) GetFreeVPNIP() (string, error) {
 	var vpnIPs []int
 	for _, cn := range cns {
 		if cn.IsVPN {
-			vpnIPs = append(vpnIPs, int(utility.IPToInt(cn.JoinIP)))
+			IPasInt := int(utility.IPToInt(cn.JoinIP))
+			vpnIPs = append(vpnIPs, IPasInt)
 		}
 	}
-	newIP, err := utility.GetAvailableID(vpnIPs, int(utility.IPToInt(as.AP.StartVPNIP)),
-		int(utility.IPToInt(as.AP.EndVPNIP)))
-	return utility.IntToIP(uint32(newIP)), err
+	return utility.GetFreeIP(utility.IPToInt(as.AP.StartVPNIP), utility.IPToInt(as.AP.EndVPNIP), vpnIPs)
 }
 
 // Only returns the connections of the AS in its function as the joining AS

--- a/models/scion_lab.go
+++ b/models/scion_lab.go
@@ -260,8 +260,7 @@ func (as *SCIONLabAS) GetFreeVPNIP() (string, error) {
 	var vpnIPs []int
 	for _, cn := range cns {
 		if cn.IsVPN {
-			IPasInt := int(utility.IPToInt(cn.JoinIP))
-			vpnIPs = append(vpnIPs, IPasInt)
+			vpnIPs = append(vpnIPs, int(utility.IPToInt(cn.JoinIP)))
 		}
 	}
 	return utility.GetFreeIP(utility.IPToInt(as.AP.StartVPNIP), utility.IPToInt(as.AP.EndVPNIP), vpnIPs)

--- a/utility/utility_test.go
+++ b/utility/utility_test.go
@@ -423,3 +423,21 @@ func TestRotateFilesExistingFiles(t *testing.T) {
 		t.Fatal("Wrong content")
 	}
 }
+
+func TestGetFreeIP(t *testing.T) {
+	// prepare a used range:
+	minStr := "10.0.8.2"
+	maxStr := "10.0.9.254"
+	alreadyInUse := []int{}
+	IP, err := GetFreeIP(IPToInt(minStr), IPToInt(maxStr), alreadyInUse)
+	if err != nil || IP != "10.0.8.2" {
+		t.Fatalf("Unexpected result. IP = %v, err = %v", IP, err)
+	}
+	for i := IPToInt(minStr); i <= IPToInt("10.0.8.254"); i++ {
+		alreadyInUse = append(alreadyInUse, int(i))
+	}
+	IP, err = GetFreeIP(IPToInt(minStr), IPToInt(maxStr), alreadyInUse)
+	if err != nil || IP != "10.0.9.1" {
+		t.Fatalf("Unexpected result. IP = %v, err = %v", IP, err)
+	}
+}


### PR DESCRIPTION
Essentially allowing to obtain e.g. 10.0.9.1 if min = 10.0.8.2 and max = 10.0.9.254 and the used IPs range from 10.0.8.2 to 10.0.8.254.

# Wait! 
We might not need this PR, we are testing...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/288)
<!-- Reviewable:end -->
