### PR TITLE
Fullsync: filter what to return.

### DIFF
--- a/controllers/api/scion_lab_ap.go
+++ b/controllers/api/scion_lab_ap.go
@@ -512,11 +512,7 @@ func (s *SCIONLabASController) GetConnectionsForAP(w http.ResponseWriter, r *htt
 	conns := []APConnectionInfo{}
 	shouldStatusBeInAP := func(status uint8) bool {
 		switch status {
-		case models.Active:
-			return true
-		case models.Create:
-			return true
-		case models.Update:
+		case models.Active, models.Create, models.Update:
 			return true
 		default:
 			return false

--- a/controllers/api/scion_lab_ap.go
+++ b/controllers/api/scion_lab_ap.go
@@ -510,17 +510,26 @@ func (s *SCIONLabASController) GetConnectionsForAP(w http.ResponseWriter, r *htt
 	}
 	// var conns []APConnectionInfo
 	conns := []APConnectionInfo{}
-	for _, cn := range cns {
-		if cn.RespondStatus != models.Active &&
-			cn.RespondStatus != models.Create &&
-			cn.RespondStatus != models.Update {
-			// not pending to add or already active -> don't send info
-			continue
+	shouldStatusBeInAP := func(status uint8) bool {
+		switch status {
+		case models.Active:
+			return true
+		case models.Create:
+			return true
+		case models.Update:
+			return true
+		default:
+			return false
 		}
+	}
+	for _, cn := range cns {
 		if cn.Updated.Unix() > cutoff {
 			continue
 		}
 		userAS := cn.GetJoinAS()
+		if !shouldStatusBeInAP(cn.RespondStatus) || !shouldStatusBeInAP(userAS.Status) {
+			continue
+		}
 		cnInfo := APConnectionInfo{
 			ASID:      userAS.IAString(),
 			IsVPN:     cn.IsVPN,


### PR DESCRIPTION
Only return ASes that are active, created or updated, with connections
to the AP that are also in those states.

Closes #297

Also in the DB we had some inconsistencies with ASes detached but with connection.respond_status!=0
Now this `SELECT COUNT(*) FROM connection WHERE join_status=0 AND respond_status <>0;` returns 0, as it should, after I've altered the offending rows. All of them where attached to AP 1-17.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/298)
<!-- Reviewable:end -->
