### PR TITLE
Do remap with getasdata

### DIFF
--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -1354,8 +1354,6 @@ func (s *SCIONLabASController) GetASData(w http.ResponseWriter, r *http.Request)
 	if !forceFlag && localVersion == as.ConfVersion {
 		w.WriteHeader(http.StatusNotModified)
 	} else if as.Status == models.Remove {
-		// write the version in the header "Coord_conv.ver" for the client to remember
-		w.Header().Add("Coord_conf.ver", strconv.FormatUint(uint64(as.ConfVersion), 10))
 		w.WriteHeader(http.StatusResetContent)
 	} else {
 		err = computeNewGenFolder(as)

--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -1332,6 +1332,7 @@ func (s *SCIONLabASController) GetASData(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	ia = as.IAString() // because we get the AS ignoring the ISD part, the real ia could be different
+	forceFlag, _ := strconv.ParseBool(r.URL.Query().Get("force"))
 	str := r.URL.Query().Get("local_version")
 	v64, err := strconv.ParseUint(str, 10, 32)
 	if err != nil {
@@ -1340,10 +1341,10 @@ func (s *SCIONLabASController) GetASData(w http.ResponseWriter, r *http.Request)
 	localVersion := uint(v64)
 	log.Printf("IA %s, current version %d, local version is %d", ia, as.ConfVersion, localVersion)
 	messageToAdmins := ""
-	if localVersion > as.ConfVersion {
+	if !forceFlag && localVersion > as.ConfVersion {
 		messageToAdmins = fmt.Sprintf("The AS with IA %s reported a possibly wrong local version "+
 			"> AS.ConvVersion (%d > %d)", ia, localVersion, as.ConfVersion)
-	} else if localVersion == as.ConfVersion {
+	} else if !forceFlag && localVersion == as.ConfVersion {
 		w.WriteHeader(http.StatusNotModified)
 	} else if as.Status == models.Remove {
 		w.WriteHeader(http.StatusResetContent)

--- a/controllers/api/scion_lab.go
+++ b/controllers/api/scion_lab.go
@@ -1317,6 +1317,7 @@ func (s *SCIONLabASController) ConfirmUpdate(w http.ResponseWriter, r *http.Requ
 // 205 (reset content) if the AS needs to delete its gen folder
 // otherwise 200 with the TGZ the AS can automatically untar and use. It will include all what the users
 // download from the web page directly (VPN, README, etc).
+// If the force=true (or force=1) flag was specified, ignore versions and assume client's is older
 // E.g. curl -s -D - --output myfile.tgz http://localhost:8080/api/as/getASData/someid/some_secret/9-ffaa_1_1?local_version=1
 func (s *SCIONLabASController) GetASData(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)

--- a/scripts/check_as_config.sh
+++ b/scripts/check_as_config.sh
@@ -3,9 +3,7 @@
 set -e
 
 SCION_COORD_URL="https://www.scionlab.org"
-# SCION_COORD_URL="http://localhost:8080"
 
-BASEDIR=$(dirname $(realpath $0))
 
 if [ ! -f $SC/gen/ia ] || [ ! -f $SC/gen/account_id ] || [ ! -f $SC/gen/account_secret ]; then
     echo "A required file is missing!"
@@ -13,7 +11,6 @@ if [ ! -f $SC/gen/ia ] || [ ! -f $SC/gen/account_id ] || [ ! -f $SC/gen/account_
     echo "Redownload your SCIONLab AS configuration and redeploy otherwise."
     exit 1
 fi
-
 IA=$(cat $SC/gen/ia | sed 's/_/\:/g')
 ACC_ID=$(cat $SC/gen/account_id)
 ACC_PW=$(cat $SC/gen/account_secret)
@@ -25,38 +22,52 @@ HTTP_CODE=$(curl -s -w "%{http_code}" "$SCION_COORD_URL/api/as/getASData/$ACC_ID
 if [ $HTTP_CODE -eq 304 ]; then
     echo "Existing AS configuration is up to date"
     exit 0
-fi
-if [ $HTTP_CODE -ne 200 ]; then
+elif [ $HTTP_CODE -eq 205 ]; then
+    echo "AS is detached"
+elif [ $HTTP_CODE -eq 200 ]; then
+    echo "New AS configuration"
+else
     echo "Unhandled status code received from Coordinator: $HTTP_CODE"
     [ -f /tmp/gen-data.tgz ] && file /tmp/gen-data.tgz | grep ASCII >/dev/null 2>&1 &&  echo "Coordinator message is:" && cat /tmp/gen-data.tgz
     exit 1
 fi
-# we received a new AS configuration
+# we received a new AS configuration or AS was detached
+cd "$SC"
 ./scion.sh stop || true
 
 TMP=$(mktemp -d)
 cd $TMP
-echo "Expanding tar file in $TMP"
-tar xf /tmp/gen-data.tgz
-# copy gen folder:
-DIR=$(ls)
-if [ $(echo $DIR | wc -l) -ne 1 ]; then
-    # failed assertion
-    echo "Expected exactly one entry in the downloaded tar file /tmp/gen-data.tgz but found a different number. Aborting"
-    exit 1
+if [ $HTTP_CODE -eq 200 ]; then
+    echo "Expanding tar file in $TMP"
+    tar xf /tmp/gen-data.tgz
+    # copy gen folder:
+    DIR=$(ls)
+    if [ $(echo $DIR | wc -l) -ne 1 ]; then
+        # failed assertion
+        echo "Expected exactly one entry in the downloaded tar file /tmp/gen-data.tgz but found a different number. Aborting"
+        exit 1
+    fi
+    DIR=$(realpath $TMP/$DIR)
+else # detaching AS
+    cp -r "$SC/gen" .
+    DIR="$TMP"
+    rm -rf $DIR/gen/ISD* $DIR/gen/dispatcher
+    echo "Guessing the new AS configuration version to be $((LOCAL_VER + 1))"
+    [ -f "$DIR/gen/coord_conf.ver" ] && echo $((LOCAL_VER + 1)) > "$DIR/gen/coord_conf.ver"
 fi
-DIR=$(realpath $TMP/$DIR)
 cd $SC
+# backup_gen
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 if [ -d gen ]; then
     mv gen "gen.bak-$TIMESTAMP" || { echo "Failed to rename gen folder. Aborting."; exit 1; }
 fi
 mv $DIR/gen .
 echo "gen folder moved into place"
+
 # copy VPN client file
-if [ -f /etc/openvpn/client.conf ] && [ -f $DIR/client.conf ]; then
+if [[ -f /etc/openvpn/client.conf  && (-f $DIR/client.conf || $HTTP_CODE -eq 205) ]]; then
     echo "Saving a backup copy of /etc/openvpn/client.conf"
-    sudo cp /etc/openvpn/client.conf "/etc/openvpn/client.conf.bak-$TIMESTAMP"
+    sudo mv /etc/openvpn/client.conf "/etc/openvpn/client.conf.bak-$TIMESTAMP"
     sudo systemctl stop "openvpn@client.service" && sleep 2 || true
 else
     echo "No /etc/openvpn/client.conf file found or not using VPN in this AS configuration. Step skipped."
@@ -72,5 +83,5 @@ fi
 echo "Reloading AS configuration"
 ./supervisor/supervisor.sh reload
 ./tools/zkcleanslate || true
-rm ./gen-cache/* || true
+rm -f ./gen-cache/*
 ./scion.sh start nobuild

--- a/scripts/check_as_config.sh
+++ b/scripts/check_as_config.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# This script asks the Coordinator for its configuration, using the IA account ID and secret and configuration
+# version stored inside the gen folder. The Coordinator can reply saying this AS has the latest version, reply with
+# a new configuration package or reply by requesting this AS to remove its configuration.
+# This script will stop SCION and start it again with the new configuration if needed.
+# This script also stops and starts the VPN client accordingly, depending on the existing configuration and the new
+# one.
+
 set -e
 
 SCION_COORD_URL="https://www.scionlab.org"
@@ -111,5 +118,6 @@ fi
 echo "Reloading AS configuration"
 ./supervisor/supervisor.sh reload
 ./tools/zkcleanslate || true
-rm -f ./gen-cache/*
+rm -f ./gen-cache/* # because we could have even changed IDs !!
+# we are not responsible for (re)building SCION:
 ./scion.sh start nobuild

--- a/scripts/check_as_config.sh
+++ b/scripts/check_as_config.sh
@@ -39,6 +39,21 @@ while getopts "hf" opt; do
 done
 
 
+onexit() {
+    CODE=$?
+    if [ $CODE -ne 0 ]; then
+        exit $CODE
+    fi
+    [ ! -z "$TEMPTGZ" ] && rm -f "/tmp/${TEMPTGZ}"
+    [ ! -z "$TEMPHEADERS" ] && rm -f "/tmp/${TEMPHEADERS}"
+    [ ! -z "$TMP" ] && rm -rf "$TMP"
+}
+trap onexit EXIT
+
+if [ -f "$SC/gen/coord_url" ]; then
+    SCION_COORD_URL=$(cat "$SC/gen/coord_url")
+    echo "Special Coordinator in use. URL: $SCION_COORD_URL"
+fi
 if [ ! -f $SC/gen/ia ] || [ ! -f $SC/gen/account_id ] || [ ! -f $SC/gen/account_secret ]; then
     echo "A required file is missing!"
     echo "Check that the directory \"$SC\" contains: \"ia\", \"account_id\" and \"account_secret\". "
@@ -52,8 +67,11 @@ ACC_PW=$(cat $SC/gen/account_secret)
 [ $force -eq 1 ] && LOCAL_VER="force=1" || LOCAL_VER="local_version=$LOCAL_VER"
 
 cd /tmp
-rm -f gen-data.tgz
-HTTP_CODE=$(curl -s -w "%{http_code}" "$SCION_COORD_URL/api/as/getASData/$ACC_ID/$ACC_PW/$IA?local_version=${LOCAL_VER}${FORCEFLAG}" --output gen-data.tgz)
+TEMPTGZ=$(mktemp gen-data-XXXXXX.tgz)
+TEMPHEADERS=$(mktemp headers-XXXXXX.txt)
+rm -f $TEMPTGZ $TEMPHEADERS
+HTTP_CODE=$(curl -s -w "%{http_code}" "$SCION_COORD_URL/api/as/getASData/$ACC_ID/$ACC_PW/$IA?${LOCAL_VER}" --output ${TEMPTGZ} -D ${TEMPHEADERS}) || { echo "curl failed with code $?. Aborting"; exit 1; }
+VERSION_IN_COORD=$(grep -oP 'Coord_conf\.ver: \K\w+' $TEMPHEADERS || true)
 if [ $HTTP_CODE -eq 304 ]; then
     echo "Existing AS configuration is up to date"
     exit 0
@@ -63,7 +81,7 @@ elif [ $HTTP_CODE -eq 200 ]; then
     echo "New AS configuration"
 else
     echo "Unhandled status code received from Coordinator: $HTTP_CODE"
-    [ -f /tmp/gen-data.tgz ] && file /tmp/gen-data.tgz | grep ASCII >/dev/null 2>&1 &&  echo "Coordinator message is:" && cat /tmp/gen-data.tgz
+    [ -f /tmp/${TEMPTGZ} ] && file /tmp/${TEMPTGZ} | grep ASCII >/dev/null 2>&1 &&  echo "Coordinator message is:" && cat /tmp/${TEMPTGZ}
     exit 1
 fi
 # we received a new AS configuration or AS was detached
@@ -74,21 +92,21 @@ TMP=$(mktemp -d)
 cd $TMP
 if [ $HTTP_CODE -eq 200 ]; then
     echo "Expanding tar file in $TMP"
-    tar xf /tmp/gen-data.tgz
+    tar xf /tmp/${TEMPTGZ}
     # copy gen folder:
     DIR=$(ls)
     if [ $(echo $DIR | wc -l) -ne 1 ]; then
         # failed assertion
-        echo "Expected exactly one entry in the downloaded tar file /tmp/gen-data.tgz but found a different number. Aborting"
+        echo "Expected exactly one entry in the downloaded tar file /tmp/${TEMPTGZ} but found a different number. Aborting"
         exit 1
     fi
     DIR=$(realpath $TMP/$DIR)
-else # detaching AS
-    cp -r "$SC/gen" .
+else # must be code 205: detaching AS
+    cp -rL "$SC/gen" .
     DIR="$TMP"
     rm -rf $DIR/gen/ISD* $DIR/gen/dispatcher
     echo "Guessing the new AS configuration version to be $((LOCAL_VER + 1))"
-    [ -f "$DIR/gen/coord_conf.ver" ] && echo $((LOCAL_VER + 1)) > "$DIR/gen/coord_conf.ver"
+    echo "$VERSION_IN_COORD" > "$DIR/gen/coord_conf.ver"
 fi
 cd $SC
 # backup_gen
@@ -103,7 +121,7 @@ echo "gen folder moved into place"
 if [[ -f /etc/openvpn/client.conf  && (-f $DIR/client.conf || $HTTP_CODE -eq 205) ]]; then
     echo "Saving a backup copy of /etc/openvpn/client.conf"
     sudo mv /etc/openvpn/client.conf "/etc/openvpn/client.conf.bak-$TIMESTAMP"
-    sudo systemctl stop "openvpn@client.service" && sleep 2 || true
+    sudo systemctl stop "openvpn@client.service" || true
 else
     echo "No /etc/openvpn/client.conf file found or not using VPN in this AS configuration. Step skipped."
 fi

--- a/scripts/check_as_config.sh
+++ b/scripts/check_as_config.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+SCION_COORD_URL="https://www.scionlab.org"
+# SCION_COORD_URL="http://localhost:8080"
+
+BASEDIR=$(dirname $(realpath $0))
+
+if [ ! -f $SC/gen/ia ] || [ ! -f $SC/gen/account_id ] || [ ! -f $SC/gen/account_secret ]; then
+    echo "A required file is missing!"
+    echo "Check that the directory \"$SC\" contains: \"ia\", \"account_id\" and \"account_secret\". "
+    echo "Redownload your SCIONLab AS configuration and redeploy otherwise."
+    exit 1
+fi
+
+IA=$(cat $SC/gen/ia | sed 's/_/\:/g')
+ACC_ID=$(cat $SC/gen/account_id)
+ACC_PW=$(cat $SC/gen/account_secret)
+[ -f $SC/gen/coord_conf.ver ] && LOCAL_VER=$(cat $SC/gen/coord_conf.ver) || LOCAL_VER=0
+
+cd /tmp
+rm -f gen-data.tgz
+curl -s -D - "$SCION_COORD_URL/api/as/getASData/$ACC_ID/$ACC_PW/$IA?local_version=$LOCAL_VER" --output gen-data.tgz
+
+
+
+
+
+# TODO check status out of the curl output. 200 => NEWGEN=1
+NEWGEN=1
+
+if [ $NEWGEN -ne 1 ]; then
+    echo "Existing AS configuration is up to date"
+    exit 0
+fi
+./scion.sh stop || true
+
+TMP=$(mktemp -d)
+cd $TMP
+echo "Expanding tar file in $TMP"
+tar xf /tmp/gen-data.tgz
+# copy gen folder:
+DIR=$(ls)
+if [ $(echo $DIR | wc -l) -ne 1 ]; then
+    # failed assertion
+    echo "Expected exactly one entry in the downloaded tar file /tmp/gen-data.tgz but found a different number. Aborting"
+    exit 1
+fi
+DIR=$(realpath $TMP/$DIR)
+cd $SC
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+if [ -d gen ]; then
+    mv gen "gen.bak-$TIMESTAMP" || { echo "Failed to rename gen folder. Aborting."; exit 1; }
+fi
+mv $DIR/gen .
+echo "gen folder moved into place"
+# copy VPN client file
+if [ -f /etc/openvpn/client.conf ] && [ -f $DIR/client.conf ]; then
+    echo "Saving a backup copy of /etc/openvpn/client.conf"
+    sudo cp /etc/openvpn/client.conf "/etc/openvpn/client.conf.bak-$TIMESTAMP"
+    sudo systemctl stop "openvpn@client.service" && sleep 2 || true
+else
+    echo "No /etc/openvpn/client.conf file found or not using VPN in this AS configuration. Step skipped."
+fi
+if [ -f $DIR/client.conf ]; then
+    echo "Using VPN in this AS configuration"
+    sudo mv $DIR/client.conf /etc/openvpn/
+    sudo systemctl start "openvpn@client.service" && sleep 2 || echo "Failed to start VPN. Please start it manually. Your AS may fail to start correctly."
+else
+    echo "Not using VPN in this AS configuration. Step skipped."
+fi
+# now reload SCION
+echo "Reloading AS configuration"
+./supervisor/supervisor.sh reload
+./tools/zkcleanslate || true
+rm ./gen-cache/* || true
+./scion.sh start nobuild

--- a/scripts/check_as_config.sh
+++ b/scripts/check_as_config.sh
@@ -4,6 +4,33 @@ set -e
 
 SCION_COORD_URL="https://www.scionlab.org"
 
+force=0
+usage="$(basename $0) [-f] [-h]
+
+where:
+    -h      This help
+    -f      (force) Ignore the configuration version
+            and get the configuration from Coordinator"
+while getopts "hf" opt; do
+    case $opt in
+    h)
+        echo "$usage"
+        exit 0
+        ;;
+    f)
+        force=1
+        ;;
+    \?)
+        echo "$usage"
+        exit 1
+        ;;
+    *)
+        echo "$usage"
+        exit 1
+        ;;
+    esac
+done
+
 
 if [ ! -f $SC/gen/ia ] || [ ! -f $SC/gen/account_id ] || [ ! -f $SC/gen/account_secret ]; then
     echo "A required file is missing!"
@@ -15,10 +42,11 @@ IA=$(cat $SC/gen/ia | sed 's/_/\:/g')
 ACC_ID=$(cat $SC/gen/account_id)
 ACC_PW=$(cat $SC/gen/account_secret)
 [ -f $SC/gen/coord_conf.ver ] && LOCAL_VER=$(cat $SC/gen/coord_conf.ver) || LOCAL_VER=0
+[ $force -eq 1 ] && LOCAL_VER="force=1" || LOCAL_VER="local_version=$LOCAL_VER"
 
 cd /tmp
 rm -f gen-data.tgz
-HTTP_CODE=$(curl -s -w "%{http_code}" "$SCION_COORD_URL/api/as/getASData/$ACC_ID/$ACC_PW/$IA?local_version=$LOCAL_VER" --output gen-data.tgz)
+HTTP_CODE=$(curl -s -w "%{http_code}" "$SCION_COORD_URL/api/as/getASData/$ACC_ID/$ACC_PW/$IA?local_version=${LOCAL_VER}${FORCEFLAG}" --output gen-data.tgz)
 if [ $HTTP_CODE -eq 304 ]; then
     echo "Existing AS configuration is up to date"
     exit 0


### PR DESCRIPTION
New script `check_as_config.sh` that will replace the remap ones.

Note: we cannot remove any of the remap API calls or scripts until 24 hours after this PR has landed in master, as the automated upgrade scripts are still using them, and we prefer them not to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/299)
<!-- Reviewable:end -->
