### PR TITLE
Reload logind.

### DIFF
--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -239,6 +239,7 @@ fi
 if [[ $keep_user_context = true ]]
 then
   sudo sh -c 'echo RemoveIPC=no >> /etc/systemd/logind.conf'
+  sudo systemctl reload-or-restart systemd-logind.service
 fi
 
 if  [[ ( ! -z ${upgrade_script+x} ) ]]

--- a/scion_upgrade_script.sh
+++ b/scion_upgrade_script.sh
@@ -3,7 +3,7 @@
 set -e
 
 # version of the systemd files:
-SERVICE_CURRENT_VERSION="0.7"
+SERVICE_CURRENT_VERSION="0.8"
 
 # version less or equal. E.g. verleq 1.9 2.0.8  == true (1.9 <= 2.0.8)
 verleq() {
@@ -89,8 +89,10 @@ if [ $dirtybuild -eq 1 ]; then
 fi
 MOTD1
                 sudo chmod 755 /etc/update-motd.d/99-scionlab-upgrade
-            fi
-        fi
+                # reload logind (inexpensive) as it seems that some user VMs still remove /run/shm when logout:
+                sudo systemctl reload-or-restart systemd-logind.service
+            fi # if [ -d "/vagrant" ]
+        fi # if [ $need_to_reload -eq 1 ]
         # don't attempt to stop the scionupgrade service as this script is a child of it and will also be killed !
         # even with KillMode=none in the service file, restarting the service here would be really delicate, as it
         # could basically hang forever if the service files don't update the version number correctly, and we would

--- a/vagrant/scionupgrade.service
+++ b/vagrant/scionupgrade.service
@@ -1,4 +1,4 @@
-# SCION upgrade version 0.7
+# SCION upgrade version 0.8
 
 [Unit]
 Description=SCION infrastructure upgrade

--- a/vagrant/scionupgrade.timer
+++ b/vagrant/scionupgrade.timer
@@ -1,4 +1,4 @@
-# SCION upgrade version 0.7
+# SCION upgrade version 0.8
 
 [Unit]
 Description=Run SCION upgrade daily


### PR DESCRIPTION
The user VMs will still remove /run/shm after installing scion unless we reload logind or reboot.
Reload logind when updating the service files, and update the service files.
Also modify the installation script to reload right after adding RemoveIPC=no to /etc/systemd/logind.conf .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/304)
<!-- Reviewable:end -->
