### PR TITLE
Forward also the control plane socket.

### DIFF
--- a/templates/Vagrantfile.tmpl
+++ b/templates/Vagrantfile.tmpl
@@ -18,6 +18,7 @@ Vagrant.configure(2) do |config|
   # BR port forwarding not necessary for OpenVPN setup and depends on connection
   {{.PortForwarding}}
   config.vm.network "forwarded_port", guest: 31042, host: 31042, protocol: "udp"
+  config.vm.network "forwarded_port", guest: 30042, host: 30042, protocol: "udp"
   config.vm.network "forwarded_port", guest: 30041, host: 30041, protocol: "udp"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
We need to forward the following: dispatcher, AS side of BR : internal address (data plane) and control address (control plane).
Additionally if not using VPN, the BR exterior port (we set it up to 50000), and also the web application.

Test it deploying a VM with the services, and another machine with a `sciond` using these services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/312)
<!-- Reviewable:end -->
