### PR TITLE
Fix bug introduced in the scion install script

### DIFF
--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -171,7 +171,7 @@ else
 fi
 # ensure we have the default certificate needed by QUIC
 if [ ! -e "gen-certs/tls.pem" -o ! -e "gen-certs/tls.key" ]; then
-    local old=$(umask)
+    old=$(umask)
     echo "Generating TLS cert"
     mkdir -p "gen-certs"
     umask 0177


### PR DESCRIPTION
The script will fail to run because a spurious `local` copied from `scion.sh`.
Test by running a VM with this script (review its `Vagrantfile` to use this one instead of downloading from master).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/314)
<!-- Reviewable:end -->
