### PR TITLE
Install also adds swap

### DIFF
--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -187,8 +187,7 @@ then
     cp -r "$gen_dir" .
 else
     echo "Gen directory is NOT specified! Generating local (Tiny) topology!"
-    ./scion.sh topology -c topology/Tiny.topo
-    rm -f gen/zk-dc.yml
+    ./scion.sh topology nodocker -c topology/Tiny.topo
 fi
 # ensure we have the default certificate needed by QUIC
 if [ ! -e "gen-certs/tls.pem" -o ! -e "gen-certs/tls.key" ]; then


### PR DESCRIPTION
depends on 
https://github.com/netsec-ethz/netsec-scion/pull/31
which is already merged.

Two things happening in this one PR:
- Add swap memory to be able to build SCION right at the installation, like we do on upgrades.
- Fix scion.sh failing if docker compose was not installed (e.g. in odroids' base image). This depends on `scion.sh topology` accepting the `nodocker` parameter (PR 31 in our netsec-scion).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/316)
<!-- Reviewable:end -->
