### PR TITLE
Publish names for user ASes

### DIFF
--- a/conf/development.conf.default
+++ b/conf/development.conf.default
@@ -84,6 +84,10 @@ heartbeat.period = 60
 # Number of heartbeat periods that can be missed before status is set to inactive
 heartbeat.limit = 10
 
+# RAINS (paths relative to scion directory)
+zonefile = /rains/zonefiles/node.snet.txt
+rains_conf = /rains/conf/publishernode.snet.conf
+
 # General settings
 # Standard port for border routers
 br_bind_start_port = 50000

--- a/conf/development.conf.default
+++ b/conf/development.conf.default
@@ -85,8 +85,8 @@ heartbeat.period = 60
 heartbeat.limit = 10
 
 # RAINS (paths relative to scion directory)
-zonefile = /rains/zonefiles/node.snet.txt
-rains_conf = /rains/conf/publishernode.snet.conf
+zonefile = /rains/zonefiles/zone.txt
+rains_conf = /rains/conf/publisherzone.conf
 
 # General settings
 # Standard port for border routers

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -90,6 +91,10 @@ var (
 	IMGBuilderBuildDelay, _   = goconf.AppConf.Int64("img_builder.build_delay")
 
 	TestingCoordinatorBranch = goconf.AppConf.String("testing_coordinator.branch")
+
+	// RAINS
+	Zonefile = goconf.AppConf.String("zonefile")
+	RainConf = goconf.AppConf.String("rains_conf")
 )
 
 func init() {
@@ -155,6 +160,9 @@ func init() {
 			os.Exit(1)
 		}
 	}
+
+	Zonefile = path.Join(os.Getenv("SC"), Zonefile)
+	RainConf = path.Join(os.Getenv("SC"), RainConf)
 }
 
 func MaxASes(isAdmin bool) int {

--- a/scion_install_script.sh
+++ b/scion_install_script.sh
@@ -20,9 +20,11 @@ where:
     -c                  do not destroy user context on logout
     -u UPGR_SCRIPT      script used for upgrading scion, (will be copied to 
                         path ${UPGRADE_SCRIPT_LOCATION})
+    -r RAINS_SRV        configures a RAINS server for name resolution at the
+                        provided address
     -t TIMER_UPG_SERV   name of sysd timer and system name for upgrades"
 
-while getopts ":p:g:v:s:z:ha:cu:t:" opt; do
+while getopts ":p:g:v:s:z:ha:cu:r:t:" opt; do
   case $opt in
     p)
       patch_dir=$OPTARG
@@ -52,6 +54,9 @@ while getopts ":p:g:v:s:z:ha:cu:t:" opt; do
       ;;
     u)
       upgrade_script=$OPTARG
+      ;;
+    r)
+      rains_config=$OPTARG
       ;;
     t)
       upgrade_timer=${OPTARG}.timer
@@ -260,6 +265,14 @@ then
     sudo cp ${upgrade_script} ${UPGRADE_SCRIPT_LOCATION}
 else
     echo "SCION upgrade script not specified."
+fi
+
+if  [[ ( -n ${rains_config+x} ) ]]
+then
+    echo "Writing RAINS configuration file"
+    echo "${rains_config}" > "$SC/gen/rains.cfg"
+else
+    echo "RAINS configuration not specified."
 fi
 
 if  [[ ( ! -z ${upgrade_service+x} ) && -r ${upgrade_service} \

--- a/utility/zoneupdate/zoneupdate.go
+++ b/utility/zoneupdate/zoneupdate.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"sort"
+
+	"github.com/netsec-ethz/rains/internal/pkg/object"
+	"github.com/netsec-ethz/rains/internal/pkg/section"
+	"github.com/netsec-ethz/rains/internal/pkg/zonefile"
+)
+
+func main() {
+
+	// flags
+	file := flag.String("zf", "zonefile.txt", "Path to zonefile")
+	name := flag.String("n", "", "name which is added to zonefile")
+	value := flag.String("v", "", "value being added to zonefile")
+
+	flag.Parse()
+
+	if *name == "" || *value == "" {
+		log.Fatal("Error: name and value cannot be empty")
+	}
+
+	zone, err := zonefile.IO{}.LoadZonefile(*file)
+	if err != nil {
+		log.Fatal(err)
+	}
+	sections := []section.Section{}
+	for _, e := range zone {
+		sections = append(sections, e)
+	}
+	if len(sections) < 1 {
+		log.Fatal("No zone found")
+	}
+	z, ok := sections[0].(*section.Zone)
+	if !ok {
+		log.Fatal("No zone found")
+	}
+	assertions := []*section.Assertion{}
+	for _, e := range z.Content {
+		// if name already present discard it
+		if e.SubjectName == *name {
+			continue
+		}
+		assertions = append(assertions, e)
+	}
+
+	// create new scionip4 assertion for name with given value
+	obj := object.Object{Type: object.OTScionAddr4, Value: *value}
+	assertion := section.Assertion{SubjectName: *name, Content: []object.Object{obj}}
+
+	// add back the other assertions plus the newly created one
+	z.Content = assertions
+	z.Content = append(z.Content, &assertion)
+	// ensure sorted ordere
+	sort.Slice(z.Content, func(i, j int) bool {
+		return z.Content[i].SubjectName < z.Content[j].SubjectName
+	})
+	zonefile.IO{}.EncodeAndStore(*file, sections)
+}


### PR DESCRIPTION
This PR makes the coordinator automatically publish names for user ASes to RAINS, both when they are newly created and when they are  reconfigured.
Additionally, the install script takes a new flag (`-r`) to configure a RAINS server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-coord/317)
<!-- Reviewable:end -->
